### PR TITLE
Git: ensure line endings normalisation for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
With this PR we ensure that text files that any contributor introduces to the repository have their line endings normalised and that shell scripts (.bash and .sh) are always checked out with LF line endings. This will prevent issues similar to #8 from happening in the future in case core.autocrlf has not been set set..