### PR TITLE
Remove codeowners file (Closes  #52)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @bss116 @dmey @ivosuter @tomgrylls @samoliverowens 


### PR DESCRIPTION
This remove the requirement for all codeowners to review every PR (as described in #52.). From now users should manually select the reviewers from the list when opening a new PR,