### PR TITLE
Revert to fpe0 for Intel compilers (closes #86) [skip ci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran
     # means they are stored on the stack (by default), whereas GNU Fortran stores
     # them on the heap (https://github.com/uDALES/u-dales/issues/13).
-    set(CMAKE_Fortran_FLAGS "-g -traceback -r8 -fpe-all0 -heap-arrays 10")
+    set(CMAKE_Fortran_FLAGS "-g -traceback -r8 -fpe0 -heap-arrays 10")
     set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -init=snan -CB -check all")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")


### PR DESCRIPTION
see https://github.com/uDALES/u-dales/issues/86#issuecomment-632664831