### PR TITLE
Add option to skip CI jobs [skip-ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   main:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')" 
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     name: ${{ matrix.os }} ${{ matrix.build-type }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This PR adds the option to skip CI jobs. Add `[skip-ci]` in your commit message to disable running jobs.