### PR TITLE
Simplify namoptions in example 201 [skip-ci]

### DIFF
--- a/examples/201/namoptions.201
+++ b/examples/201/namoptions.201
@@ -41,10 +41,8 @@ nnudge       = 64
 /
 
 &DYNAMICS
-iadv_mom     = 2
 iadv_thl     = 2
 iadv_qt      = 2
-iadv_sv      = 7
 ipoiss       = 0
 /
 


### PR DESCRIPTION
I noticed that there are parameters specified in 201 that are not different to the default, so I removed them.