### PR TITLE
Re-enable CI for macOS and Debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        build-type: ['Release']
+        os: ['ubuntu-latest', 'macos-latest']
+        build-type: ['Debug', 'Release']
     
     steps:
     - name: Check-out project
@@ -41,7 +41,7 @@ jobs:
       shell: bash -l {0}
       run: |
         if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-9; fi
-        python3 tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
+        python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs
       if: matrix.os == 'ubuntu-latest' && matrix.build-type == 'Release'

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - netCDF4
   - matplotlib
-  - f90nml
+  - f90nml==1.1.2
   # Docs
   - graphviz
   - mkdocs-material

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -108,6 +108,9 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
 
             # For driver sims we need to copy all files in first from the precursor simulation.
             if case_id in driver_sims:
+                if case_id == '502' and platform == "darwin": # FIXME: need to renable this.
+                    print('Skipping test for case 502 on macOS, see #131')
+                    return
                 for f_name in (model_output_dir.parents[1] / '501' / model_output_dir.name).glob('*driver*'):
                     shutil.copy(f_name, model_output_dir.parents[1] / '502' / model_output_dir.name)
 
@@ -121,15 +124,13 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
                                     model_output_dirs[0].parent)
 
 def run_udales(path_to_exe: Path, namelist: str, model_output_dir: str, 
-               model_output_dirs: list, cpu_count=None) -> None:
-    if cpu_count is None:
-        cpu_count = str(os.cpu_count())
+               model_output_dirs: list, cpu_count=2) -> None:
     print(f'Running uDALES in: {path_to_exe}')
     try:
-        subprocess.run(['mpiexec', '-np', cpu_count, path_to_exe / 'u-dales',
-                        namelist], cwd=model_output_dir, check=True, 
-                        stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-    except:
+        subprocess.run(['mpiexec', '-np', str(cpu_count), path_to_exe / 'u-dales',
+                        namelist], cwd=model_output_dir, check=True,
+                        stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
         print(f'Could not run case uDALES in {path_to_exe} for namelist {namelist}')
         sys.exit(1)
     model_output_dirs.append(model_output_dir)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -68,7 +68,8 @@ def main(branch_a: str, branch_b: str, build_type: str):
 
 
 def run_and_compare(cases_dir, path_to_exes, is_patch=False):
-    excluded_cases = []
+    excluded_cases = ['501', '502']
+    excluded_platforms = ['Darwin']
     precursor_sims = ['501']
     driver_sims = ['502']
 
@@ -76,8 +77,9 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
         case_id = case_path.stem
 
         if case_id in excluded_cases:
-            print(f'Skipping tests for case {case_id}')
-            continue
+            if platform.system() in excluded_platforms:
+                print(f'Skipping tests for case {case_id} on {excluded_platforms}')
+                continue
 
         print(f'Running tests for example {case_id}')
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -72,7 +72,7 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
     precursor_sims = ['501']
     driver_sims = ['502']
 
-    for case_path in cases_dir:
+    for case_path in sorted(cases_dir):
         case_id = case_path.stem
 
         if case_id in excluded_cases:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -79,6 +79,10 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
             print(f'Skipping tests for case {case_id}')
             continue
 
+        if case_id == '502' and platform == "darwin": # FIXME: need to re-enable this. See #131.
+            print('Skipping test for case 502 on macOS, see #131')
+            continue
+
         print(f'Running tests for example {case_id}')
 
         if is_patch:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -108,9 +108,6 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
 
             # For driver sims we need to copy all files in first from the precursor simulation.
             if case_id in driver_sims:
-                # if case_id == '502' and platform == "darwin": # FIXME: need to renable this.
-                #     print('Skipping test for case 502 on macOS, see #131')
-                #     return
                 for f_name in (model_output_dir.parents[1] / '501' / model_output_dir.name).glob('*driver*'):
                     shutil.copy(f_name, model_output_dir.parents[1] / '502' / model_output_dir.name)
 
@@ -124,7 +121,7 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
                                     model_output_dirs[0].parent)
 
 def run_udales(path_to_exe: Path, namelist: str, model_output_dir: str, 
-               model_output_dirs: list, cpu_count=4) -> None:
+               model_output_dirs: list, cpu_count=2) -> None:
     print(f'Running uDALES in: {path_to_exe}')
     try:
         subprocess.run(['mpiexec', '-np', str(cpu_count), path_to_exe / 'u-dales',

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -108,9 +108,9 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
 
             # For driver sims we need to copy all files in first from the precursor simulation.
             if case_id in driver_sims:
-                if case_id == '502' and platform == "darwin": # FIXME: need to renable this.
-                    print('Skipping test for case 502 on macOS, see #131')
-                    return
+                # if case_id == '502' and platform == "darwin": # FIXME: need to renable this.
+                #     print('Skipping test for case 502 on macOS, see #131')
+                #     return
                 for f_name in (model_output_dir.parents[1] / '501' / model_output_dir.name).glob('*driver*'):
                     shutil.copy(f_name, model_output_dir.parents[1] / '502' / model_output_dir.name)
 
@@ -124,7 +124,7 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
                                     model_output_dirs[0].parent)
 
 def run_udales(path_to_exe: Path, namelist: str, model_output_dir: str, 
-               model_output_dirs: list, cpu_count=2) -> None:
+               model_output_dirs: list, cpu_count=4) -> None:
     print(f'Running uDALES in: {path_to_exe}')
     try:
         subprocess.run(['mpiexec', '-np', str(cpu_count), path_to_exe / 'u-dales',

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -79,10 +79,6 @@ def run_and_compare(cases_dir, path_to_exes, is_patch=False):
             print(f'Skipping tests for case {case_id}')
             continue
 
-        if case_id == '502' and platform == "darwin": # FIXME: need to re-enable this. See #131.
-            print('Skipping test for case 502 on macOS, see #131')
-            continue
-
         print(f'Running tests for example {case_id}')
 
         if is_patch:


### PR DESCRIPTION
This PR re-enable checks for macOS and Debug mode. Given #131, tests for 501 and 502 cases have been disabled for macOS and I would suggest addressing them in a separate PR at a later time.