### PR TITLE
Fixes to bottom edge wall function as identified in #23 (closes #23)

### DIFF
--- a/src/wf_uno.f90
+++ b/src/wf_uno.f90
@@ -354,7 +354,7 @@ end if
       END DO
 
       !w west bottom edge
-      k = block(n, 6)  ! ending k-index
+      k = block(n, 5)  ! ending k-index
       if (k.gt.0) then
       km = k - 1
       DO j = jl, ju
@@ -494,7 +494,7 @@ end if
       END DO
 
      !w east edge bot
-      k = block(n, 6)  ! 
+      k = block(n, 5)  ! 
       if (k.gt.0) then
       DO j = jl, ju
          utang1Int = (utang1(i, j, k) + utang1(i, j + 1, k) + utang1(i, j + 1, k - 1) + utang1(i, j, k - 1))*0.25
@@ -623,7 +623,7 @@ end if
       END DO
 
 !w north edge bot
-      k = block(n, 6) 
+      k = block(n, 5) 
      if (k.gt.0) then
       DO i = il, iu
          utang1Int = (utang1(i, j, k) + utang1(i, j, k - 1) + utang1(i + 1, j, k) + utang1(i + 1, j, k - 1))*0.25
@@ -760,7 +760,7 @@ DO k = kl, ku
       END DO
 
 !w south edge bot
-      k = block(n, 6)
+      k = block(n, 5)
       if (k.gt.0) then 
       DO i = il, iu
          utang1Int = (utang1(i, j, k) + utang1(i, j, k - 1) + utang1(i + 1, j, k) + utang1(i + 1, j, k - 1))*0.25
@@ -833,7 +833,8 @@ DO k = kl, ku
       END DO
 
 !u top edge east
-  DO j = jl, ju
+      i = block(n, 2) + 1
+      DO j = jl, ju
          utang1Int = utang1(i, j, k)
          utang2Int = (utang2(i, j, k) + utang2(i - 1, j, k) + utang2(i, j + 1, k) + utang2(i - 1, j + 1, k))*0.25
          utangInt = max(umin, (utang1Int**2 + utang2Int**2))

--- a/src/wfmneutral.f90
+++ b/src/wfmneutral.f90
@@ -139,7 +139,7 @@ SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wfor
       END DO
 
       !w west bottom edge
-      k = block(n, 6)  ! ending k-index
+      k = block(n, 5)  ! ending k-index
       if (k.gt.0) then
       km = k - 1
       DO j = jl, ju
@@ -248,7 +248,7 @@ SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wfor
       END DO
 
      !w east edge bot
-      k = block(n, 6)  ! 
+      k = block(n, 5)  ! 
       if (k.gt.0) then
       DO j = jl, ju
          utang2Int = utang2(i, j, k)
@@ -349,7 +349,7 @@ SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wfor
       END DO
 
 !w north edge bot
-      k = block(n, 6) 
+      k = block(n, 5) 
      if (k.gt.0) then
       DO i = il, iu
          utang2Int = utang2(i, j, k)
@@ -458,7 +458,7 @@ DO k = kl, ku
       END DO
 
 !w south edge bot
-      k = block(n, 6)
+      k = block(n, 5)
       if (k.gt.0) then 
       DO i = il, iu
          utang2Int = utang2(i, j, k)
@@ -516,7 +516,8 @@ DO k = kl, ku
       END DO
 
 !u top edge east
-  DO j = jl, ju
+      i = block(n, 2) + 1
+      DO j = jl, ju
          utang1Int = utang1(i, j, k)
          dummy = (utang1Int**2)*fkar2/(logdz2)
          bcmomflux = SIGN(dummy, utang1Int)


### PR DESCRIPTION
1) Fixes to the allocation of cells when dealing with the wall function for the bottom edge of buildings. The 5th column of blocks is now called as this contains information on the lower vertical index of each block. This has limited application as in the majority of cases the starting position is `kl = 0` and we do not have floating or overhanging blocks. But is applied in complex morphologies and ensures consistency in the code.

2) A fix for the u top edge east where index `i` was not being updated to ensure that that the wall function was applied on the east face of the wall. The new line ensures the `i` index is properly allocated. This is now consistent with similar lines such as under `case(22)`.

These bugs were identified in #23 . `wfmneutral` is based upon `wf_uno` and that is why the same fixes are required in both. Following this pull request #23 can be closed as @ivosuter has confirmed that `wfmneutral` fixes that issue and has been checked for bugs.