### PR TITLE
Update licence headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 # uDALES (https://github.com/uDALES/u-dales).
-# Copyright (C) 2019 D. Meyer.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Copyright (C) 2019 the uDALES Team.
 
 cmake_minimum_required(VERSION 3.9)
 project(uDALES Fortran)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,5 +1,4 @@
 # uDALES (https://github.com/uDALES/u-dales).
-# Copyright (C) 2019 D. Meyer.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,6 +12,8 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2019 the uDALES Team.
 
 include(ExternalProject)
 

--- a/src/advec_2nd.f90
+++ b/src/advec_2nd.f90
@@ -1,6 +1,8 @@
+  
 !> \file advec_2nd.f90
 !!  Does advection with a 2nd order central differencing scheme.
-!!
+!! \par Revision list
+!! \par Authors
 !! Second order central differencing can be used for variables where neither very
 !! high accuracy nor strict monotonicity is necessary.
 !! \latexonly
@@ -10,7 +12,24 @@
 !!\end{eqnarray}
 !! \endlatexonly
 !!
+!  This file is part of DALES.
 !
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
+
 !> Advection at cell center
 subroutine advecc_2nd(hi, hj, hk, putin, putout)
 

--- a/src/advec_kappa.f90
+++ b/src/advec_kappa.f90
@@ -4,16 +4,35 @@
 !! \par Authors
 !! \see Hundsdorfer et al 1995
 !!
-!! For advection of scalars that need to be strictly monotone (for example chemically reacting species) the kappa scheme has been implemented:
+!! For advection of scalars that need to be strictly monotone (for example chemically reacting species)
+!! the kappa scheme has been implemented:
 !! \latexonly
 !! \begin{eqnarray}
 !!  F_{i-\frac{1}{2}}^{\kappa} &=& \fav{u}_{i-\frac{1}{2}}
 !!  \left[\phi_{i-1}+\frac{1}{2}\kappa_{i-\frac{1}{2}}\left(\phi_{i-1}-\phi_{i-2}\right)\right],
-!! \end{eqnarrayl}
-!! in case $\fav{u}>0$. $\kappa_{i-\smfrac{1}{2}}$ serves as a switch between higher order advection and first order upwind in case of strong upwind gradients of $\phi$.
+!! \end{eqnarray}
+!! in case $\fav{u}>0$. $\kappa_{i-\smfrac{1}{2}}$ serves as a switch between higher order advection and
+!! first order upwind in case of strong upwind gradients of $\phi$.
 !! \endlatexonly
 !! This makes the scheme monotone, but also rather dissipative.
 !!
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 
 !> Advection at cell center
   subroutine advecc_kappa(hi, hj, hk, var, varp)

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -1,8 +1,31 @@
+  
 !> \file advection.f90
+!!  Advection management
+
+!>
 !!  Advection management
 !! \par Revision list
 !! variable x-grid now possible
+!! Thijs Heus, Chiel van Heerwaarden, 15 June 2007
 !! \par Authors
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
+
 !> Advection redirection function
 subroutine advection
 

--- a/src/initfac.f90
+++ b/src/initfac.f90
@@ -5,6 +5,25 @@
 !
 !   WARNING: if walls with more than 3 layers (4 points) are to be considered, this file needs to be changed
 !            e.g. walltypes needs to read 7+4*nlayers columns, offsets in reading facet properties also change accordingly
+!
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
+!> Advection redirection function
    module initfac
       use modglobal, only:ifinput, nblocks, nfcts, cexpnr, libm, bldT, rsmin, wsoil, wfc,&
                           nwalllayers, block,lEB

--- a/src/modEB.f90
+++ b/src/modEB.f90
@@ -5,6 +5,23 @@
 !!  \author Ivo Suter
 !
 !
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 module modEB
    use modglobal
 

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -1,8 +1,23 @@
 !> \file modboundary.f90
-!>
-!>
-!! \par Revision list
 !! All boundary conditions are in this file, except for immersed boundaries.
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
+!! \par Revision list
 !! \par Authors
 !!
 module modboundary

--- a/src/modchem.f90
+++ b/src/modchem.f90
@@ -3,7 +3,24 @@
 
 !> Input chemistry of the null cycle into DALES following Zhong, Cai 2015.
 !> Assumes scalar fields are in order 1: NO, 2: NO2 and 3: O3.
-
+!
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 module modchem
 implicit none
 save

--- a/src/moddriver.f90
+++ b/src/moddriver.f90
@@ -11,6 +11,24 @@
 !! \todo Documentation
 !!       Remove unecessary "use" variables
 !!       Remove unecessary commented lines
+!
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 module moddriver
 use modinletdata
 implicit none

--- a/src/modfields.f90
+++ b/src/modfields.f90
@@ -1,10 +1,23 @@
 !> \file modfields.f90
 !!  Declares, allocates and initializes the 3D fields
 
-!>
-!!  Declares, allocates and initializes the 3D fields
-!>
-
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 
 module modfields
 

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -4,6 +4,22 @@
 !>
 !!  \author Jasper Thomas TU Delft / Ivo Suter Imperial College London
 !
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 module modibm
    use modibmdata

--- a/src/modibmdata.f90
+++ b/src/modibmdata.f90
@@ -2,7 +2,24 @@
 !!  \author Jasper Tomas,TU Delft, 31 March 2014
 !!  \par Revision list
 !!  \todo Documentation
-
+!
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 module modibmdata
   implicit none
   save

--- a/src/modinlet.f90
+++ b/src/modinlet.f90
@@ -9,7 +9,24 @@
 !!  \author Jasper Tomas,TU Delft, June 4th 2015
 !!  \par Revision list
 !!  \todo Documentation
-!!
+!
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 module modinlet
 use modinletdata
 implicit none

--- a/src/modinletdata.f90
+++ b/src/modinletdata.f90
@@ -3,7 +3,23 @@
 !!  \par Revision list
 !!  \todo Documentation
 !
-
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 module modinletdata
   implicit none
   save

--- a/src/modsave.f90
+++ b/src/modsave.f90
@@ -6,7 +6,23 @@
 !!  \todo documentation
 !!  \par Revision list
 !
-
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 module modsave
 
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -13,6 +13,22 @@
 !!  \todo documentation
 !!  \par Revision list
 !
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 
 module modstartup
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -13,6 +13,7 @@
 !!  \todo documentation
 !!  \par Revision list
 !
+!  This file is part of DALES.
 !
 ! DALES is free software; you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by

--- a/src/modstatistics.f90
+++ b/src/modstatistics.f90
@@ -3,14 +3,14 @@
 !>
 !!  \author Tom Grylls, ICL Dec 16 2016
 !
-!  This file is part of DALES.
+!  This file is part of uDALES.
 !
-! DALES is free software; you can redistribute it and/or modify
+! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation; either version 3 of the License, or
+! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
-! DALES is distributed in the hope that it will be useful,
+! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
@@ -18,7 +18,7 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
-!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!  Copyright 2006-2021 the uDALES Team.
 !
 module modstatistics
 

--- a/src/modstatsdump.f90
+++ b/src/modstatsdump.f90
@@ -3,14 +3,14 @@
 !>
 !!  \author Tom Grylls, ICL May 25 2016
 !
-!  This file is part of DALES.
+!  This file is part of uDALES.
 !
-! DALES is free software; you can redistribute it and/or modify
+! This program is free software: you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation; either version 3 of the License, or
+! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
-! DALES is distributed in the hope that it will be useful,
+! This program is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU General Public License for more details.
@@ -18,7 +18,7 @@
 ! You should have received a copy of the GNU General Public License
 ! along with this program.  If not, see <http://www.gnu.org/licenses/>.
 !
-!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!  Copyright 2006-2021 the uDALES Team.
 !
 module modstatsdump
 

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -14,6 +14,23 @@
 !!   -factor 2 smaller constant in 1-equation and Smagorinsky models
 !!  \todo Documentation
 !!
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 
 module modsubgrid
   use modsubgriddata

--- a/src/modsubgriddata.f90
+++ b/src/modsubgriddata.f90
@@ -11,6 +11,22 @@
 !!  \author Thijs Heus,MPI-M
 !!  \par Revision list
 !!  \todo Documentation
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
+!
 
 module modsubgriddata
 implicit none

--- a/src/modsubgriddata.f90
+++ b/src/modsubgriddata.f90
@@ -12,6 +12,8 @@
 !!  \par Revision list
 !!  \todo Documentation
 !
+!  This file is part of DALES.
+!
 ! DALES is free software; you can redistribute it and/or modify
 ! it under the terms of the GNU General Public License as published by
 ! the Free Software Foundation; either version 3 of the License, or

--- a/src/program.f90
+++ b/src/program.f90
@@ -1,19 +1,23 @@
 !> \file program.f90
 !! Main program
 
-!>
-!! \mainpage
-!! Dutch Atmospheric Large Eddy Simulation -URBAN
-!! \section DALES Dutch Atmospheric Large Eddy Simulation -URBAN
-!!
-!! @version 48
-!!
-!
-!! \todo
-!!
 !! \section License License
-!!  This file is part of DALESURBAN.
-!!  Copyright 1993-2014 Delft University of Technology
+!!  This file is part of DALES.
+!!
+!!  DALES is free software; you can redistribute it and/or modify it under the
+!! terms of the GNU General Public License as published by the Free Software
+!! Foundation; either version 3 of the License, or (at your option) any later
+!! version.
+!!
+!!  DALES is distributed in the hope that it will be useful, but WITHOUT ANY
+!! WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+!! PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+!!
+!!  You should have received a copy of the GNU General Public License along with
+!! this program.  If not, see <http://www.gnu.org/licenses/>.
+!!
+!!  Copyright 1993-2009 Delft University of Technology, Wageningen University,
+!! Utrecht University, KNMI
 !!
 program DALESURBAN      !Version 48
 

--- a/src/scalsource.f90
+++ b/src/scalsource.f90
@@ -1,5 +1,4 @@
 !> \file scalsource.f90
-!!tg3315, 8 Apr 2016 
 
 !> Input point, line or planar scalars
 !  This file is part of uDALES.

--- a/src/scalsource.f90
+++ b/src/scalsource.f90
@@ -2,7 +2,23 @@
 !!tg3315, 8 Apr 2016 
 
 !> Input point, line or planar scalars
-
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 subroutine createscals
 
   use modglobal,  only : nsv,ib,ie,jb,je,kb,ke,ih,jh,kh,lscasrcr,cexpnr,ifinput,imax,jmax,jtot,&

--- a/src/wf_gr.f90
+++ b/src/wf_gr.f90
@@ -1,3 +1,20 @@
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 SUBROUTINE wfGR(hi,hj,hk,ioq,ioqflux,icth,obcqfluxA,qcell,qwall,hurel,resc,ress,n,ind,wforient)
    !wfGR
    USE modglobal, ONLY : dzf,dzfi,dzh2i,dzhi,dzhiq,dy,dyi,dy2i,dyi5,dxf,dxh,dxfi,dxhi,dxh2i,ib,ie,jb,je,kb,ke,fkar,grav,jmax,rk3step

--- a/src/wf_uno.f90
+++ b/src/wf_uno.f90
@@ -1,3 +1,20 @@
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 SUBROUTINE wfuno(hi,hj,hk,iout1,iout2,iot,iomomflux,iotflux,iocth,obcTfluxA,utang1,utang2,Tcell,Twall,z0,z0h,n,ind,wforient)
    !wfuno
    !calculating wall function for momentum and scalars following Cai2012&Uno1995, extension of Louis 1979 method to rough walls

--- a/src/wfmneutral.f90
+++ b/src/wfmneutral.f90
@@ -1,3 +1,20 @@
+!  This file is part of uDALES.
+!
+! This program is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  Copyright 2006-2021 the uDALES Team.
+!
 SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wforient)
    !wfmneutral
    !wf for momentum under neutral conditions

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # uDALES (https://github.com/uDALES/u-dales).
-# Copyright (C) 2019 D. Meyer.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +14,8 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2019 the uDALES Team.
 
 
 """Test uDALES

--- a/tests/scripts/build_model.py
+++ b/tests/scripts/build_model.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # uDALES (https://github.com/uDALES/u-dales).
-# Copyright (C) 2019 D. Meyer.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +14,8 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2019 the uDALES Team.
 
 """Build uDALES with CMake.
 

--- a/tests/scripts/compare_outputs.py
+++ b/tests/scripts/compare_outputs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # uDALES (https://github.com/uDALES/u-dales).
-# Copyright (C) 2019 D. Meyer.
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +14,8 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2019 the uDALES Team.
 
 
 """Compare two netCDF datasets using approximate error.

--- a/tools/append_outputs.sh
+++ b/tools/append_outputs.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 set -e
 
 if (( $# == 2 )) ; then

--- a/tools/copy_inputs.sh
+++ b/tools/copy_inputs.sh
@@ -1,4 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 # examples:
 # new sim: "copy_inputs.sh 2 1" or "copy_inputs.sh 2 1 c"
 # continue with old sim: "copy_inputs.sh 1 1 w"

--- a/tools/examples/plot_blocks.m
+++ b/tools/examples/plot_blocks.m
@@ -1,3 +1,20 @@
+% uDALES (https://github.com/uDALES/u-dales).
+
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% Copyright (C) 2016-2021 the uDALES Team.
+
 function plot_blocks(expnr)
 
 %% Usage: matlab -nosplash -nodesktop -r "cd('tools/examples'); plot_blocks('$expnr'); quit"

--- a/tools/examples/plot_fielddump_slice.m
+++ b/tools/examples/plot_fielddump_slice.m
@@ -1,3 +1,20 @@
+% uDALES (https://github.com/uDALES/u-dales).
+
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% Copyright (C) 2016-2021 the uDALES Team.
+
 function plot_fielddump_slice(expnr, field_var, slice_var, slice_id, time_id)
 
 % Plots a slice of fielddump in 2D and 3D.

--- a/tools/examples/run_examples.sh
+++ b/tools/examples/run_examples.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 # Runs cases in the examples folders.
 # Data are saved under outputs.
 # Usage: ./tools/examples/run_and_plot_examples.sh

--- a/tools/gather_outputs.sh
+++ b/tools/gather_outputs.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 set -e
 
 if (( $# == 1 )) ; then

--- a/tools/hpc_build.sh
+++ b/tools/hpc_build.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 set -ex
 
 # Usage: ./tools/hpc_build.sh [icl, archer, cca, common] [debug, release]

--- a/tools/hpc_execute.sh
+++ b/tools/hpc_execute.sh
@@ -1,4 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
 
 set -e
 

--- a/tools/local_execute.sh
+++ b/tools/local_execute.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 # Usage: ./tools/local_execute.sh <PATH_TO_CASE>
 
 set -e

--- a/tools/nco_concatenate_field.sh
+++ b/tools/nco_concatenate_field.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 ## call: dumptype, ym-variables(list separated by comma, no space, include ym), out.nc
 ## e.g. nco_concatenate_field.sh fielddump v,ym out.nc
 

--- a/tools/preprocessing.m
+++ b/tools/preprocessing.m
@@ -1,3 +1,20 @@
+% uDALES (https://github.com/uDALES/u-dales).
+
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% Copyright (C) 2016-2021 the uDALES Team.
+
 classdef preprocessing < dynamicprops
     % Class for pre-processing in uDALES
     %

--- a/tools/singularity/udales_build.sh
+++ b/tools/singularity/udales_build.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 set -e
 
 # Usage: udales_build.sh <NPROC> [Debug, Release]

--- a/tools/singularity/udales_pbs_submit.sh
+++ b/tools/singularity/udales_pbs_submit.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 # This is an example script to submit a udales job using PBS. Modify as required.
 
 #PBS -lwalltime=00:03:00

--- a/tools/singularity/udales_run.sh
+++ b/tools/singularity/udales_run.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 set -e
 
 # Usage: udales_run.sh <NPROC> <BUILD_TYPE> <PATH_TO_CASE> <NAMELIST>

--- a/tools/write_inputs.m
+++ b/tools/write_inputs.m
@@ -1,4 +1,22 @@
 %% write_inputs
+
+% uDALES (https://github.com/uDALES/u-dales).
+
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+% Copyright (C) 2016-2021 the uDALES Team.
+
 % This script is run by the bash script da_inp.sh.
 % It used to generate the necessary input files for uDALES.
 

--- a/tools/write_inputs.sh
+++ b/tools/write_inputs.sh
@@ -1,4 +1,22 @@
-#!/bin/bash                                                                                        
+#!/usr/bin/env bash
+
+# uDALES (https://github.com/uDALES/u-dales).
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016-2019 the uDALES Team.
+
 # script for setting key namoptions and writing *.inp.* files
 # variables not specified in namoptions can be set here. It updates these in write_inputs.m and then runs the matlab code to produce the required text files.
 


### PR DESCRIPTION
This PR adds/updates the licence header and copyright notice. @tomgrylls and @ivosuter please can you check and let me know.

~There are however a few files which have no authorship information and are not included in the dales repo therefore I am not sure which copyright should apply (i.e. DALES or uDALES). Could you please check the following files and let me know?~

~1. These seem to be IBM related so I think they should be DALES but please double check:~

~modibm.f90~
~modibmdata.f90~
~modinlet.f90~
~modinletdata.f90~
~modsave.f90~

~2.  These I don't know:~

~wf_gr.f90~
~wf_uno.f90~
~wfmneutral.f90~

EDIT: point 1 is addressed in 51cff24 and point 2 in e580661