### PR TITLE
Add zenodo metadata file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,49 @@
+{
+    "title": "uDALES: large-eddy-simulation software for urban flow, dispersion, and microclimate modelling",
+    "description": "<p>uDALES, a free and open-source large-eddy-simulation software for urban flow, dispersion, and microclimate modelling. For more information about uDALES, please refer to the <a href=\"https://github.com/uDALES/u-dales#readme\">uDALES repository on GitHub</a>.</p>", 
+    "keywords": [
+        "fluid-dynamics", 
+        "computational-fluid-dynamics", 
+        "large-eddy-simulation", 
+        "urban-climate", 
+        "fortran"
+      ],
+    "creators": [
+        {
+          "orcid": "0000-0002-0948-4932", 
+          "name": "Grylls, T."
+        },
+        {
+          "orcid": "0000-0002-8612-4033", 
+          "name": "Suter, I."
+        },
+        {
+          "orcid": "0000-0001-9638-5643", 
+          "name": "Sützl, B."
+        },
+        {
+          "orcid": "0000-0003-3253-1896", 
+          "name": "Owens, S."
+        },
+        {
+          "orcid": "0000-0002-7071-7547", 
+          "name": "Meyer, D."
+        },
+        {
+          "orcid": "0000-0003-4840-5050", 
+          "name": "van Reeuwijk, M."
+        }
+      ],
+      "access_right": "open",
+      "license": {
+        "id": "GPL-3.0"
+      },
+      "related_identifiers": [
+        {
+          "scheme": "doi", 
+          "identifier": "10.21105/joss.03055", 
+          "relation": "isSupplementTo", 
+          "resource_type": "publication-article"
+        }
+      ]
+}


### PR DESCRIPTION
This PR allows for automatically automatically archiving new releases onto Zenodo.
@tomgrylls you need to enable this from the Zenodo dashboard before releasing -- see https://guides.github.com/activities/citable-code/.
Note:  merge this in before 1.0.0 release.