### PR TITLE
Use latest gfortran version in tests and fix debug compilation.

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,4 +7,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
+    brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -4,7 +4,7 @@ set -xe
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
-    sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
+    sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz libfftw3-dev
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz fftw
     brew unlink gcc

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,5 +6,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install gfortran netcdf open-mpi graphviz
+    brew install netcdf open-mpi graphviz
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -4,9 +4,9 @@ set -xe
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
-    sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz libfftw3-dev
+    sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install netcdf open-mpi graphviz fftw
+    brew install netcdf open-mpi graphviz
     brew unlink gcc
     brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,7 +6,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install netcdf open-mpi graphviz
+    brew install netcdf open-mpi graphviz fftw
     brew unlink gcc
     brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,5 +6,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install netcdf open-mpi graphviz
+    brew install gfortran netcdf open-mpi graphviz
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,5 +7,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
-    brew link gcc
+    brew unlink gcc
+    brew link gcc@10
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,5 +7,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
+    brew unlink gcc
     brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,6 +7,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
-    brew unlink gcc
-    brew link gcc@10
+    brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,5 +7,4 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
-    brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,8 +7,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf netcdf-fortran open-mpi graphviz
-    nc-config --all
-    nf-config --all
-    brew unlink gcc
     brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,6 +7,5 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
-    brew unlink gcc
-    brew link gcc@9
+    brew link gcc
 fi

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,7 +6,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install netcdf open-mpi graphviz
+    brew install netcdf netcdf-fortran open-mpi graphviz
     nc-config --all
     nf-config --all
     brew unlink gcc

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -7,6 +7,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install netcdf open-mpi graphviz
+    nc-config --all
+    nf-config --all
     brew unlink gcc
     brew link gcc
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-12; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-10; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-10; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-9; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-12; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -Wall -Warray-bounds -Wuninitialized -Wunused -Wsurprising -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -Wall -Wuninitialized -Wunused-variable -Wextra -Wconversion -pedantic")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion -pedantic")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fbounds-check -Wunused-variable -Wextra -Wconversion -pedantic")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wunused-variable -Wuninitialized -Warray-bounds -Wconversion")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wunused-variable -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fbounds-check -Wunused-variable -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -Wall -Warray-bounds -Wuninitialized -Wunused -Wsurprising -Wextra -Wconversion -pedantic")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -Wall -Wuninitialized -Wunused-variable -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -pedantic")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran


### PR DESCRIPTION
Commit https://github.com/uDALES/u-dales/commit/26fe1fa1fe016f1277f494132630ada1cdc8ad70 enables compilation using gfortran 10 and above, but the tests use gfortran version 9. This PR updates the test to use the latest version of gfortran.