### PR TITLE
Adding scalar sink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
+    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
     set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
+    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
     set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -213,6 +213,10 @@ module modglobal
    real    :: dtfac = 10.
    real    :: tfac = 0. !time of last calculation of facet quantites
    real    :: tnextfac = 0. !time for next calculation of facet energy balance
+   logical :: lperiodicEBcorr = .false. ! Switch used to correct periodic heat build up.
+   integer :: sinkbase = 0 ! This is the z index above which a sink is applied in periodicEBcorr scheme
+   real    :: fraction = 1 ! Fraction of excess heat removed by volume sink in periodic energy balance correction.
+
    logical :: lvfsparse = .false. !< whether to read in view factors in sparse format
    integer :: nnz !< number of non-zero view factors
    logical :: lconstW = .false.  ! The evaporated water can be removed from the soil (lconstW=false) or the soil moisture can be assumed as constant in time (lconstW=true)
@@ -381,6 +385,9 @@ module modglobal
    real :: dtEB = 10. !time interval between calculations of facet energy balance
    real :: tEB = 0. !time of last calculation of facet energy balance
    real :: tnextEB = 0. !time for next calculation of facet energy balance
+   real :: totheatflux = 0. ! Total sensible heat flux from facs into air in one timestep
+   real :: totqflux  = 0. ! Total latent heat flux from facs into air in one timestep
+
 
    real :: thres = 5.e-3 !<     * threshold value for inversion height calculations
    real :: dqt !<     * applied gradient of qt at top of model

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -67,7 +67,7 @@ module modstartup
                                     lzerogradtopscal, lbuoyancy, ltempeq, &
                                     lfixinlet, lfixutauin, pi, &
                                     thlsrc, ifixuinf, lvinf, tscale, ltempinout, lmoistinout,  &
-                                    lwallfunc,lprofforc,lchem,k1,JNO2,rv,rd,tnextEB,tEB,dtEB,bldT,flrT,wsoil,wgrmax,wwilt,wfc,skyLW,GRLAI,rsmin,nfcts,lEB,lwriteEBfiles,nfaclyrs,lconstW,lvfsparse,nnz,lfacTlyrs, &
+                                    lwallfunc,lprofforc,lchem,k1,JNO2,rv,rd,tnextEB,tEB,dtEB,bldT,flrT, lperiodicEBcorr, fraction,sinkbase,wsoil,wgrmax,wwilt,wfc,skyLW,GRLAI,rsmin,nfcts,lEB,lwriteEBfiles,nfaclyrs,lconstW,lvfsparse,nnz,lfacTlyrs, &
                                     BCxm,BCxT,BCxq,BCxs,BCym,BCyT,BCyq,BCys,BCzp,ds, &
                                     BCtopm,BCtopT,BCtopq,BCtops,BCbotm,BCbotT,BCbotq,BCbots, &
                                     BCxm_periodic, BCym_periodic, &
@@ -150,8 +150,8 @@ module modstartup
          nfctsecs_u, nfctsecs_v, nfctsecs_w, nfctsecs_c, lbottom, lnorec, &
          prandtlturb, fkar, lwritefac, dtfac
       namelist/ENERGYBALANCE/ &
-         lEB, lwriteEBfiles, lconstW, dtEB, bldT, flrT, wsoil, wgrmax, wwilt, wfc, &
-         skyLW, GRLAI, rsmin, nfaclyrs, lfacTlyrs, lvfsparse, nnz
+         lEB, lwriteEBfiles, lperiodicEBcorr, sinkbase, lconstW, dtEB, bldT, flrT, wsoil, wgrmax, wwilt, wfc, &
+         skyLW, GRLAI, rsmin, nfaclyrs, lfacTlyrs, lvfsparse, nnz, fraction
       namelist/SCALARS/ &
          lreadscal, lscasrc, lscasrcl, lscasrcr, &
          nsv, nscasrc, nscasrcl								!!xS, yS, zS, SS, sigS
@@ -538,6 +538,9 @@ module modstartup
       call MPI_BCAST(dtEB, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(bldT, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(flrT, 1, MY_REAL, 0, comm3d, mpierr)
+      call MPI_BCAST(lperiodicEBcorr, 1, MPI_LOGICAL, 0, comm3d, mpierr)
+      call MPI_BCAST(sinkbase, 1, MPI_INTEGER, 0, comm3d, mpierr)
+      call MPI_BCAST(fraction, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(skyLW, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(GRLAI, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(rsmin, 1, MY_REAL, 0, comm3d, mpierr)

--- a/src/program.f90
+++ b/src/program.f90
@@ -32,7 +32,7 @@ program DALESURBAN      !Version 48
   use modboundary,       only : initboundary,boundary,grwdamp,halos
   use modthermodynamics, only : initthermodynamics,thermodynamics
   use modsubgrid,        only : initsubgrid,subgrid
-  use modforces,         only : calcfluidvolumes,forces,coriolis,lstend,fixuinf1,fixuinf2,fixthetainf,nudge,masscorr,shiftedPBCs
+  use modforces,         only : calcfluidvolumes,forces,coriolis,lstend,fixuinf1,fixuinf2,fixthetainf,nudge,masscorr,shiftedPBCs,periodicEBcorr
   use modpois,           only : initpois,poisson
   use modibm,            only : initibm,createmasks,ibmwallfun,ibmnorm,bottom
   use modtrees,          only : createtrees,trees
@@ -153,6 +153,7 @@ program DALESURBAN      !Version 48
     call nudge          ! nudge top cells of fields to enforce steady-state
 
     call ibmwallfun     ! immersed boundary forcing: only shear forces.
+    call periodicEBcorr
 
     call masscorr       ! correct pred. velocity pup to get correct mass flow
 


### PR DESCRIPTION
Introduce new subroutine in modforces that can implement a scalar sink to prevent the build up of moisture and heat in a periodic domain. It requires lperiodicEBcorr = .true., sinkbase (the k index at which the sink starts)  and fraction (the fraction of flux to be removed by the sink) to be defined in ENERGYBALANCE in namoptions. 