### PR TITLE
Fix MPI related warnings with gfortran

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
+    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
     set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")

--- a/src/initfac.f90
+++ b/src/initfac.f90
@@ -25,6 +25,7 @@
 !
 !> Advection redirection function
    module initfac
+      use mpi
       use modglobal, only : ifinput, nfcts, cexpnr, libm, bldT, flrT, rsmin, wsoil, wfc, &
                            nfaclyrs, block, lEB, lvfsparse, nnz, lfacTlyrs, lwritefac
       use modmpi,   only : myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, cmyid, MPI_REAL8, MPI_REAL4, MPI_SUM, mpi_logical

--- a/src/modEB.f90
+++ b/src/modEB.f90
@@ -24,6 +24,7 @@
 !
 module modEB
   use modglobal
+  use mpi
 
   implicit none
   public :: EB, initEB, intqH, updateGR

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -21,6 +21,7 @@
 !! \par Authors
 !!
 module modboundary
+   use mpi
 
    implicit none
    save

--- a/src/modfielddump.f90
+++ b/src/modfielddump.f90
@@ -27,6 +27,7 @@
 !
 module modfielddump
 
+  use mpi
   use modglobal, only : longint
   use modfields, only : ncname, ncname1, ncname2
   implicit none

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -22,6 +22,7 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 module modibm
+   use mpi
    use modibmdata
    !use wf_uno
    implicit none

--- a/src/modinlet.f90
+++ b/src/modinlet.f90
@@ -28,6 +28,7 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 module modinlet
+use mpi
 use modinletdata
 implicit none
 save

--- a/src/modpurifiers.f90
+++ b/src/modpurifiers.f90
@@ -4,6 +4,7 @@
 !> Input air purifiers into DALES model.
 
 module modpurifiers
+use mpi
 implicit none
 save
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -33,6 +33,7 @@
 
 module modstartup
 
+   use mpi
    implicit none
    ! private
    ! public :: startup,trestart

--- a/src/modstatsdump.f90
+++ b/src/modstatsdump.f90
@@ -22,6 +22,7 @@
 !
 module modstatsdump
 
+  use mpi
   use modglobal, only : dt,lydump,lytdump,ltkedump,lxydump,lxytdump,ltdump,lmintdump,ifoutput !,nstat
   use modmpi, only : myid
   implicit none

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -33,6 +33,7 @@
 !
 
 module modsubgrid
+  use mpi
   use modsubgriddata
   implicit none
   save

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -31,6 +31,7 @@
 
 module modtimedep
 
+use mpi
 
 implicit none
 private

--- a/src/modtrees.f90
+++ b/src/modtrees.f90
@@ -4,6 +4,7 @@
 !> Input trees into DALES model.
 
 module modtrees
+use mpi
 implicit none
 save
 


### PR DESCRIPTION
This PR address some compilation warnings seen with gfortran of the form:

> /home/ccaveayl/projects/u-dales/u-dales/src/modtimedep.f90:279:19:
> 
>   142 |       call MPI_BCAST(timeflux, ntimedepsurf, MY_REAL, 0, comm3d, mpierr)
>       |                     2
> ......
>   279 |     call MPI_BCAST(ltimedepsurf ,1,MPI_LOGICAL,0,comm3d,mpierr)
>       |                   1
> Warning: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/REAL(8)).

Whist usually an error, this behaviour was being suppressed by using `-fallow-argument-mismatch` when compiling.

The root cause of the errors was not including `use mpi` in the relevant modules. Without `use mpi` the compiler does not know anything about `MPI_BCAST` and assumes that it will be provided at link time. When it sees the same unknown function being called with different data types it flags this as an issue. Adding in `use mpi` makes the compiler aware of the generic interface for `MPI_BCAST` so it knows that it's ok for it to be called in multiple different ways.

This PR also removes the compiler flag that is no longer needed.
