### PR TITLE
Enforce standard Fortran 2008

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
+    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -std=f2008")
     set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")

--- a/src/moddriver.f90
+++ b/src/moddriver.f90
@@ -188,7 +188,7 @@ contains
     real :: inlrec                              ! time of last inlet record
     real :: elapsrec                            ! time elapsed in this inlet record
     real :: dtint                               ! dt for linear interpolation
-    REAL*8, PARAMETER :: eps = 1d-4
+    real, PARAMETER :: eps = 1d-4
     integer i,j,k,kk,kdamp,x,xc
 
     if (idriver == 1 .and. iplanerank) then
@@ -223,12 +223,12 @@ contains
         if (.not.(lwarmstart)) then
           if (runtime>maxval(storetdriver)) then
             write(*,'(A,F15.5,A,F15.5,A)') "Simulation will stop before runtime = ",runtime,", since last &
-                                            read driver time (",maxval(storetdriver),") is less than runtime."
+                                            &read driver time (",maxval(storetdriver),") is less than runtime."
           end if
         else ! if lwarmstart
           if (runtime+btime>maxval(storetdriver)) then
             write(*,'(A,F15.5,A,F15.5,A)') "Simulation will stop before runtime+btime = ",runtime+btime,", since last &
-                                            read driver time (",maxval(storetdriver),") is less than runtime+btime."
+                                            &read driver time (",maxval(storetdriver),") is less than runtime+btime."
           end if
         end if
       end if
@@ -737,18 +737,18 @@ contains
     if (.not.(lwarmstart)) then
       if (driverid==0 .and. runtime+1e-10 < (tdriverstart + (driverstore-1)*dtdriver)) then
         write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                    Consider taking runtime >= (tdriverstart + (driverstore-1)*dtdriver).'
+                    &Consider taking runtime >= (tdriverstart + (driverstore-1)*dtdriver).'
       end if
     else ! if lwarmstart
       if (btime<tdriverstart) then
         if(driverid==0 .and. (btime + runtime) < (tdriverstart + (driverstore-1)*dtdriver) ) then
           write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                      Consider taking runtime + ',btime,' >= (tdriverstart + (driverstore-1)*dtdriver).'
+                      &Consider taking runtime + ',btime,' >= (tdriverstart + (driverstore-1)*dtdriver).'
         end if
       else
         if (driverid==0 .and. runtime+1e-10 < (driverstore-1)*dtdriver ) then
           write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                      Consider taking runtime >= (driverstore-1)*dtdriver).'
+                      &Consider taking runtime >= (driverstore-1)*dtdriver).'
         end if
       end if
     end if

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -416,7 +416,7 @@ module modglobal
    logical :: ladaptive = .false. !<    * adaptive timestepping on or off
 
    real    :: tdriverstart = 0.   !<     * time at which to start recording inlet driver file (only necessary if idriver == 1)
-   real    :: tdriverstart_cold = 0.	!< to store tdriverstart of cold started simulation while doing warmstart
+   real    :: tdriverstart_cold = 0.   !< to store tdriverstart of cold started simulation while doing warmstart
    real    :: tdriverdump         !<     * time in inlet driver simulation at which data dumps are made (idriver == 1)
    real    :: dtdriver = 0.1      !<     * time frequency at which inlet driver data dumps are made (idriver == 1)
    integer :: driverstore         !<     * number of stored driver steps for inlet (automatically calculated)

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -50,9 +50,9 @@ save
   real, allocatable :: pz_top(:,:,:), py_top(:,:,:), px_top(:,:,:)
   integer :: ibc1, ibc2, kbc1, kbc2
 
-  integer*8 :: plan_r2fc_x, plan_r2fc_y, plan_fc2r_x, plan_fc2r_y
-  integer*8 :: plan_r2fr_x, plan_r2fr_y, plan_fr2r_x, plan_fr2r_y
-  integer*8 :: plan_r2fr_z, plan_fr2r_z
+  integer :: plan_r2fc_x, plan_r2fc_y, plan_fc2r_x, plan_fc2r_y
+  integer :: plan_r2fr_x, plan_r2fr_y, plan_fr2r_x, plan_fr2r_y
+  integer :: plan_r2fr_z, plan_fr2r_z
   real, allocatable :: Sxr(:), Sxfr(:), Syr(:), Syfr(:), Szr(:), Szfr(:)
   complex, allocatable :: Sxfc(:), Syfc(:)
   type(DECOMP_INFO) :: sp

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -156,7 +156,7 @@ module modstartup
          skyLW, GRLAI, rsmin, nfaclyrs, lfacTlyrs, lvfsparse, nnz, fraction
       namelist/SCALARS/ &
          lreadscal, lscasrc, lscasrcl, lscasrcr, &
-         nsv, nscasrc, nscasrcl								!!xS, yS, zS, SS, sigS
+         nsv, nscasrc, nscasrcl !!xS, yS, zS, SS, sigS
       namelist/CHEMISTRY/ &
          lchem, k1, JNO2
       namelist/OUTPUT/ &
@@ -796,12 +796,12 @@ module modstartup
 
          if (ltempeq .and. (BCxT .ne. BCxT_profile) .and. (myid == 0)) then
            write (*, *) "Warning: x inflow temperature not given by profile, &
-                         consider setting BCxT = ", BCxT_profile
+                         &consider setting BCxT = ", BCxT_profile
          end if
 
          if (lmoist .and. (BCxq .ne. BCxq_profile) .and. (myid == 0)) then
            write (*, *) "Warning: x inflow moisture not given by profile, &
-                        consider setting BCxq = ", BCxq_profile
+                        &consider setting BCxq = ", BCxq_profile
          end if
 
          if (BCtopm .ne. BCtopm_pressure) then
@@ -870,17 +870,17 @@ module modstartup
 
          if (ltempeq .and. (BCyT .ne. BCyT_profile) .and. (myid == 0)) then
            write (*, *) "Warning: y inflow temperature not given by profile, &
-                         consider setting BCyT = ", BCyT_profile
+                         &consider setting BCyT = ", BCyT_profile
          end if
 
          if (lmoist .and. (BCyq .ne. BCyq_profile) .and. (myid == 0)) then
            write (*, *) "Warning: y inflow moisture not given by profile, &
-                        consider setting BCyq = ", BCyq_profile
+                        &consider setting BCyq = ", BCyq_profile
          end if
 
          if (BCtopm .ne. BCtopm_pressure .and. (myid == 0)) then
            write (*, *) "Warning: allowing vertical velocity at top might be necessary, &
-                         consider setting BCtopm = ", BCtopm_pressure
+                         &consider setting BCtopm = ", BCtopm_pressure
          end if
        end select
 
@@ -1483,7 +1483,7 @@ module modstartup
                                            trestart mentioned in namoptions. Hence, trestart = ',(tdriverstart + (driverstore-1)*dtdriver)
                      if (runtime >= tdriverstart .and. runtime+1e-10 < (tdriverstart + (driverstore-1)*dtdriver)) then
                         write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                                    Consider taking runtime >= (tdriverstart + (driverstore-1)*dtdriver).'
+                                    &Consider taking runtime >= (tdriverstart + (driverstore-1)*dtdriver).'
                      end if
                   end if
                end if
@@ -1673,15 +1673,15 @@ module modstartup
                   end if
 
                   if (myid==0) then
-                     write(*,'(A,F15.5)') "Warning! during warmstart of driver simulation, tdriverstart &
-                                           gets overwritten by the time instant of initd restartfile, ignoring the &
-                                           tdriverstart mentioned in namoptions. Hence, tdriverstart = ",timee
+                     write(*,'(A,F15.5)') "Warning! during warmstart of driver simulat ion, tdriverstart &
+                                           &gets overwritten by the time instant of initd restartfile, ignoring the &
+                                           &tdriverstart mentioned in namoptions. Hence, tdriverstart = ",timee
                      write(*,'(A,F15.5)') 'Warning! for this driver simulation, trestart gets set as &
                                            (driverstore-1)*dtdriver, ignoring the trestart mentioned &
                                            in namoptions. Hence, trestart = ',(driverstore-1)*dtdriver
                      if ( runtime < (driverstore-1)*dtdriver ) then
                         write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                                    Consider taking runtime >= (driverstore-1)*dtdriver).'
+                                    &Consider taking runtime >= (driverstore-1)*dtdriver).'
                      end if
                   end if
 
@@ -1695,7 +1695,7 @@ module modstartup
                                            trestart mentioned in namoptions. Hence, trestart = ',(tdriverstart + (driverstore-1)*dtdriver) - btime
                      if ( (timee + runtime) < (tdriverstart + (driverstore-1)*dtdriver) ) then
                         write(*,*) 'Warning! Driver files cannot be written upto ', driverstore, ' steps. &
-                                    Consider taking runtime + ',timee,' >= (tdriverstart + (driverstore-1)*dtdriver).'
+                                    &Consider taking runtime + ',timee,' >= (tdriverstart + (driverstore-1)*dtdriver).'
                      end if
                   end if
                end if

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -304,10 +304,10 @@ contains
           iret=nf90_def_var(ncID,sx(n,1),NF90_FLOAT,dim_tttts,VarID)
 
 !Facet information
-		case ('ft')
-		  iret=nf90_def_var(ncID,sx(n,1),NF90_FLOAT,dim_ft,VarID)
-		case ('flt')
-		  iret=nf90_def_var(ncID,sx(n,1),NF90_FLOAT,dim_flt,VarID)
+       case ('ft')
+          iret=nf90_def_var(ncID,sx(n,1),NF90_FLOAT,dim_ft,VarID)
+       case ('flt')
+          iret=nf90_def_var(ncID,sx(n,1),NF90_FLOAT,dim_flt,VarID)
 
         case default
         write(0, *) 'nvar', nvar, sx(n,:)


### PR DESCRIPTION
Started looking at this as part of #206 but it seems the code base can be brought fully in line with standard Fortran 2008 (at least according to gfortran) with a few small tweaks. This PR implements the small changes necessary and adds the `-std=f2008` flag for gfortran in cmake.

Overall I'd strongly suggest formally adopting the 2008 standard as it's readily achievable and will help to ensure cross compiler/system compatibility in the long term.

I'll check if ifort has any additional recommendations as a follow up.