### PR TITLE
Remove duplicate declaration of mpi constants

### DIFF
--- a/src/initfac.f90
+++ b/src/initfac.f90
@@ -28,7 +28,7 @@
       use mpi
       use modglobal, only : ifinput, nfcts, cexpnr, libm, bldT, flrT, rsmin, wsoil, wfc, &
                            nfaclyrs, block, lEB, lvfsparse, nnz, lfacTlyrs, lwritefac
-      use modmpi,   only : myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, cmyid, MPI_REAL8, MPI_REAL4, MPI_SUM, mpi_logical
+      use modmpi,   only : myid, comm3d, mpierr, MY_REAL, nprocs, cmyid
       use netcdf
       implicit none
       public :: readfacetfiles,qsat,dqsatdT,netsw

--- a/src/modEB.f90
+++ b/src/modEB.f90
@@ -251,7 +251,7 @@ contains
     !initialise everything necessary to calculate the energy balance
     use modglobal, only:AM, BM,CM,DM,EM,FM,GM, HM, IDM, inAM, bb,w,dumv,Tdash, bldT, nfcts,nfaclyrs
     use initfac, only:facd, faccp, faclam, fackappa, netsw, facem, fachf, facef, fachfi, facT, facLWin,facefi,facwsoil,facf,facets,facTdash,facqsat,facf,fachurel
-    use modmpi, only:myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, cmyid, MPI_REAL8, MPI_REAL4, MPI_SUM
+    use modmpi, only:myid, comm3d, mpierr, MY_REAL, nprocs, cmyid
     use modstat_nc,only: open_nc, define_nc,ncinfo,writestat_dims_nc
     integer :: i,j,k,l,m,n
     real :: dum
@@ -420,7 +420,7 @@ contains
     !calculates the energy balance for every facet
     use modglobal, only: nfcts, boltz, tEB, AM, BM,CM,DM,EM,FM,GM,HM, inAM, bb,w, dumv,Tdash, timee, tnextEB, rk3step, rhoa, cp, lEB, ntrun, lwriteEBfiles,nfaclyrs
     use initfac, only: faclam, faccp, netsw, facem, fachf, facef, fachfi, facT, facLWin, faca,facefi,facf,facets,facTdash,facqsat,facwsoil,facf,fachurel,facd,fackappa
-    use modmpi, only: myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, cmyid, MPI_REAL8, MPI_REAL4, MPI_SUM
+    use modmpi, only: myid, comm3d, mpierr, MY_REAL, nprocs, cmyid
     use modstat_nc, only : writestat_nc, writestat_1D_nc, writestat_2D_nc
     real  :: ca = 0., cb = 0., cc = 0., cd = 0., ce = 0., cf = 0.
     real  :: ab = 0.

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -244,7 +244,7 @@ module modibm
 
    subroutine initibmnorm(fname, solid_info)
      use modglobal, only : ifinput
-     use modmpi,    only : myid, comm3d, MPI_INTEGER, mpierr
+     use modmpi,    only : myid, comm3d, mpierr
      use decomp_2d, only : zstart, zend
 
      character(11), intent(in) :: fname
@@ -304,7 +304,7 @@ module modibm
    subroutine initibmwallfun(fname_bnd, fname_sec, dir, bound_info)
      use modglobal, only : ifinput, ib, ie, itot, ih, jb, je, jtot, jh, kb, ktot, kh, &
                            xf, yf, zf, xh, yh, zh, dx, dy, dzh, dzf, xhat, yhat, zhat, eps1
-     use modmpi,    only : myid, comm3d, MPI_INTEGER, MY_REAL, MPI_LOGICAL, mpierr
+     use modmpi,    only : myid, comm3d, MY_REAL, mpierr
      use initfac,   only : facnorm, facz0
      use decomp_2d, only : zstart, zend
 
@@ -2116,7 +2116,7 @@ module modibm
       use modfields, only : IIc,  IIu,  IIv,  IIw,  IIuw,  IIvw,  IIuv,  &
                             IIcs, IIus, IIvs, IIws, IIuws, IIvws, IIuvs, &
                             IIct, IIut, IIvt, IIwt, IIuwt, um, u0, vm, v0, wm, w0
-      use modmpi,    only : myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, MPI_SUM
+      use modmpi,    only : myid, comm3d, mpierr, MY_REAL, nprocs
       use decomp_2d, only : zstart, exchange_halo_z
 
       integer :: IIcl(kb:ke + khc), IIul(kb:ke + khc), IIvl(kb:ke + khc), IIwl(kb:ke + khc), IIuwl(kb:ke + khc), IIvwl(kb:ke + khc), IIuvl(kb:ke + khc)

--- a/src/modpurifiers.f90
+++ b/src/modpurifiers.f90
@@ -11,7 +11,7 @@ save
 contains
     subroutine createpurifiers
     use modglobal,  only : lpurif,npurif,purif,cexpnr,ifinput
-    use modmpi,     only : myid,MPI_INTEGER,comm3d,mpierr
+    use modmpi,     only : myid,comm3d,mpierr
 
     implicit none
     integer :: n

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -702,7 +702,7 @@ module modstartup
                               ipoiss,POISS_FFT2D,POISS_FFT3D,POISS_CYC,&
                               lydump,lytdump,luoutflowr,lvoutflowr,&
                               lhdriver,lqdriver,lsdriver
-      use modmpi,      only : myid, comm3d, mpierr, MPI_INTEGER, MPI_LOGICAL, nprocx, nprocy
+      use modmpi,      only : myid, comm3d, mpierr, nprocx, nprocy
       use modglobal,   only : idriver
       implicit none
       real :: d(1:itot-1)
@@ -2398,8 +2398,8 @@ module modstartup
    !    use modfields, only:IIc, IIu, IIv, IIw, IIuw, IIvw, IIuv, IIct, IIwt, IIut, IIuwt, IIvt,&
    !       IIcs, IIus, IIuws, IIvws, IIuvs, IIvs, IIws, &
    !       um, u0, vm, v0, wm, w0
-   !    use modmpi, only:myid, comm3d, mpierr, MPI_INTEGER, MPI_DOUBLE_PRECISION, MY_REAL, nprocs, &
-   !       cmyid, MPI_REAL8, MPI_REAL4, MPI_SUM, excjs
+   !    use modmpi, only:myid, comm3d, mpierr, MY_REAL, nprocs, &
+   !       cmyid, excjs
    !    ! use initfac, only:block
    !    integer k, n, il, iu, jl, ju, kl, ku
    !    integer :: IIcl(kb:ke + khc), IIul(kb:ke + khc), IIvl(kb:ke + khc), IIwl(kb:ke + khc), IIuwl(kb:ke + khc), IIvwl(kb:ke + khc), IIuvl(kb:ke + khc)

--- a/src/modtrees.f90
+++ b/src/modtrees.f90
@@ -13,7 +13,7 @@ contains
     use modglobal,  only : ltrees,ntrees,tree,cexpnr,ifinput,zh,zf,dzh,dzfi,dzhi,dzf,Qstar,&
                            dec,lad,kb,ke,cp,rhoa,ntree_max,dQdt,tr_A,dy,xh
     use modfields,  only : um,vm,wm,thlm,qt0,svp,up,vp,wp,thlp,qtp,Rn,clai,qc,qa,ladzh,ladzf
-    use modmpi,     only : myid,MPI_INTEGER,comm3d,mpierr,MY_REAL
+    use modmpi,     only : myid,comm3d,mpierr,MY_REAL
     use modsurfdata,only : wtsurf
     use modibmdata ,only : bctfz
     implicit none


### PR DESCRIPTION
Module modmpi was using MPI_INTEGER, MPI_DOUBLE_PRECISION etc. from mpi, which were causing conflicts when importing mpi and modmpi elsewhere, resulting in failed builds.

This PR removes importing standard MPI constants when mpi is already used.