### PR TITLE
Pass build type correctly in hpc_build.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (default Release)" FORCE)
 endif()
 
+# check that cmake build type is a valid value
+set(CMAKE_CONFIGURATION_TYPES Debug Release)
+if (NOT ${CMAKE_BUILD_TYPE} IN_LIST CMAKE_CONFIGURATION_TYPES)
+  message(FATAL_ERROR "Build type '${CMAKE_BUILD_TYPE}' not supported.")
+endif()
+
 set(SKIP_UPDATE_EXTERNAL_PROJECTS OFF CACHE STRING "Update external projects")
 if (SKIP_UPDATE_EXTERNAL_PROJECTS)
     message(STATUS "Skipping updating external projects")

--- a/tools/hpc_build.sh
+++ b/tools/hpc_build.sh
@@ -81,7 +81,7 @@ pushd $path_to_build_dir
 cmake_build_type="$(capitalize $build_type)"
 FC=$FC cmake -DNETCDF_DIR=$NETCDF_DIR \
              -DNETCDF_FORTRAN_DIR=$NETCDF_FORTRAN_DIR \
-             -DCMAKE_BUILD_TYPE=cmake_build_type \
+             -DCMAKE_BUILD_TYPE=$cmake_build_type \
 	     -DFFTW_DOUBLE_OPENMP_LIB=$FFTW_DOUBLE_LIB \
 	     -DFFTW_FLOAT_OPENMP_LIB=$FFTW_FLOAT_LIB \
               ../../ 2>&1 | tee -a $path_to_build_dir/config.log


### PR DESCRIPTION
The helper script `hpc_build.sh` had a bug that means that the build type was being passed as the string "cmake_build_type" rather than "Debug" or "Release". This fixes that issue and adds a check to cmake that the build type value is set to either "Debug" or "Release".