### PR TITLE
Tidy up existing CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,3 @@ jobs:
       run: |
         FC=${{ matrix.FC }} python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
-    - name: Build docs
-      if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release'
-      run: |
-        mkdocs build --site-dir build/html
-        ford docs/udales-docs-software.md
-
-    - name: Publish docs
-      if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release' && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: build/html/
-        force_orphan: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,10 @@ jobs:
     
     steps:
     - name: Check-out project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
-
-    - name: Set up repository
-      # Clone all history leading to the tip of a single branch
-      # See https://stackoverflow.com/a/44036486.
-      run: |
-        git remote set-branches --add origin master
-        git fetch origin master
+        fetch-depth: 0  # get all branches
 
     - name: Install system dependencies
       run: bash .github/scripts/install_deps.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-22.04', 'macos-14']
         build-type: ['Debug', 'Release']
     
     steps:
@@ -35,18 +35,18 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-12; fi
+        if [ ${{ matrix.os }} = 'macos-14 ]; then export FC=gfortran-12; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs
-      if: matrix.os == 'ubuntu-latest' && matrix.build-type == 'Release'
+      if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release'
       shell: bash -l {0}
       run: |
         mkdocs build --site-dir build/html
         ford docs/udales-docs-software.md
 
     - name: Publish docs
-      if: matrix.os == 'ubuntu-latest' && matrix.build-type == 'Release' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release' && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: ['ubuntu-22.04', 'macos-14']
         build-type: ['Debug', 'Release']
+        include:
+          - os: macos-14
+            FC: gfortran-12  # add the FC variable to macos runs
     defaults:
       run:
         # 'shell' required to activate environment.
@@ -36,8 +39,7 @@ jobs:
 
     - name: Build and test uDALES
       run: |
-        if [ ${{ matrix.os }} = 'macos-14 ]; then export FC=gfortran-12; fi
-        python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
+        FC=${{ matrix.FC }} python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs
       if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on: [push, pull_request]
 
 jobs:
   main:
-    # https://stackoverflow.com/a/59775665/8893833
-    if: "!contains(github.event.commits[0].message, '[skip ci]')"
     name: ${{ matrix.os }} ${{ matrix.build-type }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
       matrix:
         os: ['ubuntu-22.04', 'macos-14']
         build-type: ['Debug', 'Release']
-    
+    defaults:
+      run:
+        # 'shell' required to activate environment.
+        # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
+        shell: bash -el {0}
     steps:
     - name: Check-out project
       uses: actions/checkout@v4
@@ -31,16 +35,12 @@ jobs:
         environment-file: environment.yml
 
     - name: Build and test uDALES
-      # 'shell' required to activate environment.
-      # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
-      shell: bash -l {0}
       run: |
         if [ ${{ matrix.os }} = 'macos-14 ]; then export FC=gfortran-12; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs
       if: matrix.os == 'ubuntu-22.04' && matrix.build-type == 'Release'
-      shell: bash -l {0}
       run: |
         mkdocs build --site-dir build/html
         ford docs/udales-docs-software.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   main:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  docs:
+    name: Publish docs
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        # 'shell' required to activate environment.
+        # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
+        shell: bash -el {0}
+    steps:
+    - name: Check-out project
+      uses: actions/checkout@v4
+    - name: Install python dependencies
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-version: "latest"
+        auto-update-conda: true
+        activate-environment: udales
+        environment-file: environment.yml
+    - name: Build docs
+      run: |
+        mkdocs build --site-dir build/html
+        ford docs/udales-docs-software.md
+    - name: Publish docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/html/
+        force_orphan: true


### PR DESCRIPTION
This PR takes a pass at the existing workflows to tidy them up a bit. Comprises:

- Moving publication of documentation to a separate `on: release` workflow.
- Runs the existing CI workflow only on pull request.
- Pins the versions of images used by CI runners.
- Removes/simplifies some job steps.

Closes #202 