### PR TITLE
Move debug flags to debug build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,20 +39,20 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
+    set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-g -fbacktrace -O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran
     # means they are stored on the stack (by default), whereas GNU Fortran stores
     # them on the heap (https://github.com/uDALES/u-dales/issues/13).
-    set(CMAKE_Fortran_FLAGS "-g -traceback -r8 -fpe0 -heap-arrays 10")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -init=snan -CB -check all")
+    set(CMAKE_Fortran_FLAGS "-r8 -fpe0 -heap-arrays 10")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-g -traceback -O0 -init=snan -CB -check all")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
     # https://pubs.cray.com/content/S-3901/8.5/cray-fortran-reference-manual-85
-    set(CMAKE_Fortran_FLAGS "-G0 -s real64 -N 1023 -K trap=divz,inv,ovf")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ei -R bcdps -m 0")
+    set(CMAKE_Fortran_FLAGS "-s real64 -N 1023 -K trap=divz,inv,ovf")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-G0 -O0 -ei -R bcdps -m 0")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 else()
     message(FATAL_ERROR "Only GNU, Intel, and Cray Fortran compilers are supported")


### PR DESCRIPTION
This PR moves the debug flags from `CMAKE_Fortran_FLAGS` to `CMAKE_Fortran_FLAGS_DEBUG`, so that `CMAKE_Fortran_FLAGS_RELEASE` works correctly for release builds.