### PR TITLE
Fix simple compiler warnings

### DIFF
--- a/src/advec_2nd.f90
+++ b/src/advec_2nd.f90
@@ -33,12 +33,8 @@
 !> Advection at cell center
 subroutine advecc_2nd(hi, hj, hk, putin, putout)
 
-   use modglobal, only:ih, jh, kh, kb, ke, ib, ie, jb, je, dxi, dxi5, dyi, dyi5, dzf, dzfi, dzhi, dzfi5, libm, jmax
+   use modglobal, only:kb, ke, ib, ie, jb, je, dxi5, dyi5, dzf, dzhi, dzfi5
    use modfields, only:u0, v0, w0
-   use modibm, only:nxwallsnorm, nzwallsnorm, nywallsm, nywallsp, ywallsm, ywallsp, &
-      xwallsnorm, zwallsnorm, iypluswall, iyminwall, nyminwall, nypluswall
-   use initfac, only:block
-   use modmpi, only:myid
    implicit none
 
    integer, intent(in) :: hi !< size of halo in i
@@ -47,7 +43,7 @@ subroutine advecc_2nd(hi, hj, hk, putin, putout)
    real, dimension(ib - hi:ie + hi, jb - hj:je + hj, kb - hk:ke + hk), intent(in)  :: putin !< Input: the cell centered field
    real, dimension(ib - hi:ie + hi, jb - hj:je + hj, kb:ke + hk), intent(inout) :: putout !< Output: the tendency
 
-   integer :: i, j, k, ip, im, jp, jm, kp, km, il, iu, jl, ju, kl, ku, n
+   integer :: i, j, k, ip, im, jp, jm, kp, km
    do k = kb, ke
       km = k - 1
       kp = k + 1
@@ -92,18 +88,16 @@ end subroutine advecc_2nd
 !> Advection at the u point.
 subroutine advecu_2nd(putin, putout)
 
-   use modglobal, only:ih, ib, ie, jb, je, jh, kb, ke, kh, dxi, dxiq, dyiq, dzf, dzfi5, dzhi, libm, imax, jmax, ktot
-   use modfields, only:u0, v0, w0, pres0, uh, vh, wh, pres0h
-   use modibm, only:nxwallsnorm, nzwallsnorm, nywallsm, nywallsp, ywallsm, ywallsp, &
-      xwallsnorm, zwallsnorm
-   use modmpi, only:myid
+   use modglobal, only:ih, ib, ie, jb, je, jh, kb, ke, kh, dxi, dxiq, dyiq, dzf, dzfi5, dzhi
+   use modfields, only:u0, v0, w0, pres0
+
    use decomp_2d
    implicit none
 
    real, dimension(ib - ih:ie + ih, jb - jh:je + jh, kb - kh:ke + kh), intent(in)  :: putin !< Input: the u-field
    real, dimension(ib - ih:ie + ih, jb - jh:je + jh, kb:ke + kh), intent(inout) :: putout !< Output: the tendency
 
-   integer :: i, j, k, ip, im, jp, jm, kp, km, il, iu, jl, ju, kl, ku, n
+   integer :: i, j, k, ip, im, jp, jm, kp, km
 
    do k = kb, ke
       km = k - 1
@@ -153,7 +147,7 @@ end subroutine advecu_2nd
 !> Advection at the v point.
 subroutine advecv_2nd(putin, putout)
 
-   use modglobal, only:ih, ib, ie, jh, jb, je, kb, ke, kh, dx, dxi, dxiq, dyiq, dzf, dzfi5, dzhi, dyi
+   use modglobal, only:ih, ib, ie, jh, jb, je, kb, ke, kh, dxiq, dyiq, dzf, dzfi5, dzhi, dyi
    use modfields, only:u0, v0, w0, pres0
    implicit none
 
@@ -211,7 +205,7 @@ end subroutine advecv_2nd
 !> Advection at the w point.
 subroutine advecw_2nd(putin, putout)
 
-   use modglobal, only:ih, ib, ie, jh, jb, je, kb, ke, kh, dx, dxi, dxiq, dyiq, dzf, dzhi, dzhiq
+   use modglobal, only:ih, ib, ie, jh, jb, je, kb, ke, kh, dxiq, dyiq, dzf, dzhi, dzhiq
    use modfields, only:u0, v0, w0, pres0
    ! use modmpi, only : myid
    implicit none

--- a/src/advec_kappa.f90
+++ b/src/advec_kappa.f90
@@ -38,9 +38,7 @@
   subroutine advecc_kappa(hi, hj, hk, var, varp)
 
 !  use modglobal, only : i1,i2,ih,j1,j2,jh,k1,kmax,dxi,dyi,dzi
-     use modglobal, only:ib, ie, ihc, jb, je, jhc, kb, ke, khc, dxhci, dyi, dzhci, dxfc, dzfc, dxfci, dzfci, libm
-     use modibmdata, only:nxwallsnorm, nywallsnorm, nzwallsnorm, xwallsnorm, &
-        ywallsnorm, zwallsnorm, nywallsp, nywallsm, ywallsp, ywallsm
+     use modglobal, only:ib, ie, jb, je, kb, ke, dxhci, dyi, dzhci, dxfc, dzfc, dxfci, dzfci
      use modfields, only:u0, v0, w0
      implicit none
      real, external :: rlim
@@ -52,7 +50,7 @@
      real, dimension(ib - hi:ie + hi, jb - hj:je + hj, kb:ke + hk)      ::  duml ! 3d dummy variable: lower cell side
      real, dimension(ib - hi:ie + hi, jb - hj:je + hj, kb:ke + hk)      ::  dumu ! 3d dummy variable: upper cell side
 
-     integer i, j, k, il, iu, jl, ju, kl, ku, n
+     integer i, j, k
      real :: cf, d1, d2
 
      dumu(:, :, :) = 0.

--- a/src/advec_upw.f90
+++ b/src/advec_upw.f90
@@ -23,7 +23,7 @@
 !> Advection at cell center
 subroutine advecc_upw(hi, hj, hk, putin, putout)
 
-   use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, dyi, dxfci, dzfci
+   use modglobal, only:ib, ie, jb, je, kb, ke, dyi, dxfci, dzfci
    use modfields, only:u0, v0, w0
    implicit none
 

--- a/src/advection.f90
+++ b/src/advection.f90
@@ -32,7 +32,7 @@ subroutine advection
    use modglobal, only:lmoist, nsv, iadv_mom, iadv_tke, iadv_thl, iadv_qt, iadv_sv, &
       iadv_cd2, iadv_kappa, iadv_upw, &
       ltempeq, ih, jh, kh, ihc, jhc, khc, kb, ke, ib, ie, jb, je
-   use modfields, only:u0, up, v0, vp, w0, wp, e120, e12p, thl0, thl0c, thlp, thlpc, qt0, qtp, sv0, svp, pres0, uh, vh, wh, pres0h
+   use modfields, only:u0, up, v0, vp, w0, wp, e120, e12p, thl0, thl0c, thlp, thlpc, qt0, qtp, sv0, svp
    use modsubgriddata, only:loneeqn
    use decomp_2d
    implicit none

--- a/src/initfac.f90
+++ b/src/initfac.f90
@@ -86,7 +86,7 @@
     contains
 
       subroutine readfacetfiles
-        use modglobal, only: block, cexpnr, iwallmom, iwalltemp, iwallmoist
+        use modglobal, only: cexpnr, iwallmom, iwalltemp, iwallmoist
         implicit none
 
         !use modglobal, only:block
@@ -99,7 +99,7 @@
         !use modglobal, only : nblocks, nfcts, cexpnr, ifinput
         character (len = 13) :: FILE_VF = 'vf.nc.inp.xxx'
         integer :: ncid, varid
-        integer :: n = 0, m = 0, i = 0, j = 0, k = 0, io = 0
+        integer :: n = 0, m = 0, i = 0, j = 0, io = 0
         integer :: iret
 
         if (.not.(nfcts > 0)) return

--- a/src/modEB.f90
+++ b/src/modEB.f90
@@ -219,9 +219,8 @@ contains
 
   subroutine intqH !time integration of heat and latent heat from facets
     use modglobal, only:nfcts, dt, rk3step, lEB
-    use initfac, only:faccth, fachfsum, fachf, fachfi, facef, facefi, facefsum
-    use modmpi, only:nprocs, myid, comm3d, mpierr, mpi_sum, my_real
-    real :: dummy
+    use initfac, only:fachfsum, fachf, fachfi, facef, facefi, facefsum
+    use modmpi, only:myid, comm3d, mpierr, mpi_sum, my_real
     integer :: n
 
     if (.not. lEB) return
@@ -249,12 +248,10 @@ contains
 
   subroutine initEB
     !initialise everything necessary to calculate the energy balance
-    use modglobal, only:AM, BM,CM,DM,EM,FM,GM, HM, IDM, inAM, bb,w,dumv,Tdash, bldT, nfcts,nfaclyrs
-    use initfac, only:facd, faccp, faclam, fackappa, netsw, facem, fachf, facef, fachfi, facT, facLWin,facefi,facwsoil,facf,facets,facTdash,facqsat,facf,fachurel
-    use modmpi, only:myid, comm3d, mpierr, MY_REAL, nprocs, cmyid
+    use modglobal, only:AM, BM,CM,DM,EM,FM,GM, HM, IDM, inAM, bb,w,dumv,nfcts,nfaclyrs
+    use modmpi, only:myid
     use modstat_nc,only: open_nc, define_nc,ncinfo,writestat_dims_nc
-    integer :: i,j,k,l,m,n
-    real :: dum
+    integer :: j,m
 
     if (.not. lEB) return
 
@@ -338,7 +335,7 @@ contains
   subroutine calclw
     !calculate the longwave exchange between facets
     use modglobal, only:nfcts, boltz, skyLW, nnz
-    use initfac, only:facem, vf, svf, faca, facT, facLWin, facets, vfsparse, ivfsparse, jvfsparse
+    use initfac, only:facem, vf, svf, facT, facLWin, vfsparse, ivfsparse, jvfsparse
     integer :: n, m, i, j
     real :: ltemp = 0.
 
@@ -380,11 +377,10 @@ contains
     ! bare soil
     ! E = max(0,(1-vegetation%) * rhoa * (qa-qsat(TGR)*hu) * (1/(rs+ra))
 
-    use modglobal, only:nfcts, rlv, rlvi, rhoa, cp, wfc, wwilt, wsoil, rsmin, GRLAI, tEB, rsmax, lconstW
-    use initfac, only:netSW, faccth, fachurel, faclGR, facwsoil, facf, facef, facT, facefi, facqsat, facd, faca, qsat
+    use modglobal, only:nfcts, rlv, rlvi, rhoa, wfc, wwilt, rsmin, GRLAI, tEB, rsmax, lconstW
+    use initfac, only:netSW, fachurel, faclGR, facwsoil, facf, facT, facefi, facqsat, facd, faca, qsat
 
     integer :: n
-    real :: vfraction = 0.8 !fraction of GR covered in vegetation, should be made into a proper model parameter (-> modglobal)
     real :: dum
     do n = 1, nfcts
 
@@ -418,14 +414,13 @@ contains
 
   subroutine EB
     !calculates the energy balance for every facet
-    use modglobal, only: nfcts, boltz, tEB, AM, BM,CM,DM,EM,FM,GM,HM, inAM, bb,w, dumv,Tdash, timee, dtEB, tnextEB, rk3step, rhoa, cp, lEB, ntrun, lwriteEBfiles,nfaclyrs
-    use initfac, only: faclam, faccp, netsw, facem, fachf, facef, fachfi, facT, facLWin, faca,facefi,facf,facets,facTdash,facqsat,facwsoil,facf,fachurel,facd,fackappa
-    use modmpi, only: myid, comm3d, mpierr, MY_REAL, nprocs, cmyid
+    use modglobal, only: nfcts, boltz, tEB, BM,CM,DM,EM,FM,GM,HM, inAM, bb,w, dumv,timee, dtEB, tnextEB, rk3step, rhoa, cp, lEB, lwriteEBfiles,nfaclyrs
+    use initfac, only: faclam, faccp, netsw, facem, fachfi, facT, facLWin, faca,facefi,facf,facets,facTdash,facqsat,facwsoil,facf,fachurel,facd
+    use modmpi, only: myid, comm3d, mpierr, MY_REAL
     use modstat_nc, only : writestat_nc, writestat_1D_nc, writestat_2D_nc
-    real  :: ca = 0., cb = 0., cc = 0., cd = 0., ce = 0., cf = 0.
+    real  :: ca = 0., cb = 0.
     real  :: ab = 0.
-    integer :: l, n, m,i,j
-    character(19) name
+    integer :: n, m,i,j
 
     if (.not. (lEB)) return
     !calculate latent heat flux from vegetation and soil

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -66,7 +66,7 @@ contains
    ! Needs to be called before divergence is calculated
    subroutine halos
 
-      use modglobal, only : ib, ie, ih, jb, je, jh, kb, ke, kh, ihc, jhc, khc, nsv, &
+      use modglobal, only : ihc, jhc, khc, nsv, &
                             BCxm, BCym, BCxT, BCyT, BCxq, BCyq, BCxs, BCys, &
                             BCxm_periodic, BCxT_periodic, BCxq_periodic, BCxs_periodic, &
                             BCym_periodic, BCyT_periodic, BCyq_periodic, BCys_periodic, &
@@ -74,7 +74,7 @@ contains
       use modfields, only : u0, v0, w0, um, vm, wm, thl0, thlm, qt0, qtm, sv0, svm, thl0c
       use decomp_2d, only : exchange_halo_z
       implicit none
-      integer i, k, n
+      integer n
 
       call exchange_halo_z(u0)
       call exchange_halo_z(v0)
@@ -113,7 +113,7 @@ contains
    !! Set boundary conditions for the next timestep
    ! Will result in velocity field being not divergence-free
    subroutine boundary
-      use modglobal,      only : ib, ie, ih, jb, je, jh, kb, ke, kh, ihc, jhc, khc, dzf, zh, nsv, &
+      use modglobal,      only : kb, ke, khc, dzf, zh, nsv, &
                                  ltempeq, lmoist, luvolflowr, luoutflowr, &
                                  BCxm, BCym, BCxT, BCyT, BCxq, BCyq, BCxs, BCys, BCtopm, BCtopT, BCtopq, BCtops, &
                                  BCtopm_freeslip, BCtopm_noslip, BCtopm_pressure, &
@@ -127,18 +127,17 @@ contains
                                  ibrank, ierank, jbrank, jerank, e12min, idriver, &
                                  Uinf, Vinf, &
                                  rk3step, lchunkread
-      use modfields,      only : u0, v0, w0, um, vm, wm, thl0, thlm, qt0, qtm, e120, e12m, sv0, svm, u0av, v0av, uouttot, vouttot, thl0c
+      use modfields,      only : u0, v0, w0, um, vm, wm, thl0, thlm, qt0, qtm, e120, e12m, u0av, v0av, uouttot, vouttot, thl0c
       use modsubgriddata, only : ekh, ekm, loneeqn
       use modsurfdata,    only : thl_top, qt_top, sv_top, wttop, wqtop, wsvtop
-      use modmpi,         only : myid, slabsum, avey_ibm
+      use modmpi,         only : slabsum, avey_ibm
       use moddriver,      only : drivergen, driverchunkread
-      use modinletdata,   only : ubulk, vbulk, iangle
+      use modinletdata,   only : ubulk, vbulk
       use decomp_2d,      only : exchange_halo_z
 
       implicit none
       real, dimension(kb:ke) :: uaverage, vaverage
-      real, dimension(ib:ie,kb:ke) :: uavey
-      integer i, k, n
+      integer k, n
 
      ! if not using massflowrate need to set outflow velocity
      if (luoutflowr) then
@@ -392,7 +391,7 @@ contains
 
    subroutine closurebc
      use modsubgriddata, only : ekm, ekh
-     use modglobal,      only : ib, ie, jb, je, kb, ke, ih, jh, kh, numol, prandtlmoli, &
+     use modglobal,      only : ib, ie, jb, je, kb, ke, numol, prandtlmoli, &
                                 ibrank, ierank, jbrank, jerank, BCtopm, BCxm, BCym, &
                                 BCtopm_freeslip, BCtopm_noslip, BCtopm_pressure, &
                                 BCxm_periodic, BCym_periodic
@@ -465,10 +464,10 @@ contains
    subroutine xm_periodic
       use modglobal, only : ib, ie, ih
       use modfields, only : u0, um, v0, vm, w0, wm, e120, e12m
-      use modsubgriddata, only : loneeqn, lsmagorinsky
+      use modsubgriddata, only : loneeqn
       use modmpi, only : excis
 
-      integer n, m
+      integer m
 
       do m = 1, ih
          u0(ib - m, :, :) = u0(ie + 1 - m, :, :)
@@ -537,7 +536,7 @@ contains
    subroutine xs_periodic
       use modglobal, only : ib, ie, ihc
       use modfields, only : sv0, svm
-      integer m, n
+      integer m
 
       do m = 1, ihc
          sv0(ib - m, :, :, :) = sv0(ie + 1 - m, :, :, :)
@@ -551,12 +550,12 @@ contains
 
    !>set lateral periodic boundary conditions for momentum in y/j direction
    subroutine ym_periodic
-      use modglobal, only:ib, ie, jb, je, ih, jh, kb, ke, kh, jmax
-      use modfields, only:u0, um, v0, vm, w0, wm, e120, e12m, shear
-      use modsubgriddata, only:loneeqn, lsmagorinsky
+      use modglobal, only:jb, je, ih
+      use modfields, only:u0, um, v0, vm, w0, wm, e120, e12m
+      use modsubgriddata, only:loneeqn
       use modmpi, only:excjs
 
-      integer n, m
+      integer m
 
       do m = 1, ih
          u0(:, jb - m, :) = u0(:, je + 1 - m, :)
@@ -588,7 +587,7 @@ contains
    subroutine yT_periodic
       use modglobal, only : jb, je, jh, jhc
       use modfields, only : thl0, thlm, thl0c
-      use modmpi, only:excjs, myid, nprocs
+      use modmpi, only:excjs
       integer m
 
       do m = 1, jh
@@ -643,7 +642,7 @@ contains
 
 
      subroutine xmi_profile
-       use modglobal,      only : ib, ie, jb, je, kb, ke
+       use modglobal,      only : ib, jb, je, kb, ke
        use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m, uprof, vprof, e12prof
        use modsubgriddata, only : loneeqn
 
@@ -675,9 +674,9 @@ contains
 
 
      subroutine xmi_driver
-       use modglobal,      only : ib, ie, jb, je, kb, ke
+       use modglobal,      only : ib, jb, je, kb, ke
        use modinletdata,   only : u0driver, umdriver, v0driver, vmdriver, w0driver, wmdriver
-       use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m, e12prof
+       use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m
        use modsubgriddata, only : loneeqn
 
        integer j, k
@@ -721,7 +720,7 @@ contains
 
 
      subroutine xTi_profile
-       use modglobal, only : ib, ie, jb, je, kb, ke
+       use modglobal, only : ib, jb, je, kb, ke
        use modfields, only : thl0, thlm, thlprof
        integer j, k
 
@@ -751,7 +750,7 @@ contains
 
 
      subroutine xTi_driver
-       use modglobal,    only : ib, ie, jb, je, kb, ke
+       use modglobal,    only : ib, jb, je, kb, ke
        use modinletdata, only : thl0driver, thlmdriver
        use modfields,    only : thl0, thlm
        integer j, k
@@ -767,7 +766,7 @@ contains
 
 
      subroutine xqi_profile
-       use modglobal,    only : ib, ie, jb, je, kb, ke
+       use modglobal,    only : ib, jb, je, kb, ke
        use modfields,    only : qt0, qtm, qtprof
        integer j, k
 
@@ -782,7 +781,7 @@ contains
 
 
    subroutine xqi_driver
-     use modglobal,    only : ib, ie, jb, je, kb, ke
+     use modglobal,    only : ib, jb, je, kb, ke
      use modinletdata, only : qt0driver, qtmdriver
      use modfields,    only : qt0, qtm
 
@@ -799,7 +798,7 @@ contains
 
 
    subroutine xsi_profile
-     use modglobal,    only : ib, ie, jb, je, kb, ke, nsv, ihc
+     use modglobal,    only : ib, jb, je, kb, ke, nsv, ihc
      use modfields,    only : sv0, svm, svprof
 
      integer j, k, n, m
@@ -819,7 +818,7 @@ contains
 
 
      subroutine xsi_custom
-       use modglobal,    only : ib, ie, jb, je, jtot, kb, ke, nsv, ihc
+       use modglobal,    only : ib, jb, je, jtot, kb, ke, nsv, ihc
        use modfields,    only : sv0, svm, svprof
        use decomp_2d,    only : zstart
 
@@ -842,7 +841,7 @@ contains
 
 
    subroutine xsi_driver
-     use modglobal,    only : ib, ie, ihc, jb, je, jhc, kb, ke, khc, nsv
+     use modglobal,    only : ib, ihc, jb, je, kb, ke, nsv
      use modinletdata, only : sv0driver, svmdriver
      use modfields,    only : sv0, svm
 
@@ -864,11 +863,11 @@ contains
 
    subroutine xmo_convective
      use modglobal,      only : ie, dxi, rk3step, dt
-     use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m, uouttot
+     use modfields,      only : v0, vm, w0, wm, e120, e12m, uouttot
      use modsubgriddata, only : loneeqn
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      v0(ie + 1, :, :) = v0(ie+1, :, :) - (v0(ie+1, :, :) - v0(ie, :, :))*dxi*rk3coef*uouttot
      w0(ie + 1, :, :) = w0(ie+1, :, :) - (w0(ie+1, :, :) - w0(ie, :, :))*dxi*rk3coef*uouttot
@@ -885,7 +884,7 @@ contains
 
    subroutine xmo_Neumann
      use modglobal,      only : ie
-     use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m
+     use modfields,      only : v0, vm, w0, wm, e120, e12m
      use modsubgriddata, only : loneeqn
 
      v0(ie + 1, :, :) = v0(ie, :, :)
@@ -906,7 +905,7 @@ contains
      use modfields, only : thl0, thlm, uouttot
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      thl0(ie + 1, :, :) = thl0(ie+1, :, :) - (thl0(ie + 1, :, :) - thl0(ie, :, :))*dxi*rk3coef*uouttot
      thlm(ie + 1, :, :) = thlm(ie+1, :, :) - (thlm(ie + 1, :, :) - thlm(ie, :, :))*dxi*rk3coef*uouttot
@@ -929,7 +928,7 @@ contains
      use modfields, only : qt0, qtm, uouttot
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      qt0(ie + 1, :, :) = qt0(ie, :, :) - (qt0(ie + 1, :, :) - qt0(ie, :, :))*dxi*rk3coef*uouttot
      qtm(ie + 1, :, :) = qtm(ie, :, :) - (qtm(ie + 1, :, :) - qtm(ie, :, :))*dxi*rk3coef*uouttot
@@ -943,7 +942,7 @@ contains
      real rk3coef
      integer n
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        sv0(ie + 1, :, :, n) = sv0(ie + 1, :, :, n) - (sv0(ie + 1, :, :, n) - sv0(ie, :, :, n))*dxi*rk3coef*uouttot
@@ -954,12 +953,12 @@ contains
 
 
    subroutine xso_Neumann
-     use modglobal, only : ie, ihc, rk3step, dt, dxi, nsv
+     use modglobal, only : ie, ihc, rk3step, dt, nsv
      use modfields, only :sv0, svm
      real rk3coef
      integer n, m
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        do m = 1, ihc
@@ -972,7 +971,7 @@ contains
 
 
    subroutine ymi_profile
-     use modglobal,      only : ib, ie, jb, je, kb, ke
+     use modglobal,      only : ib, ie, jb, kb, ke
      use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m, uprof, vprof, e12prof
      use modsubgriddata, only : loneeqn
      integer i, k
@@ -1003,7 +1002,7 @@ contains
 
 
    subroutine yTi_profile
-     use modglobal, only : ib, ie, jb, je, kb, ke
+     use modglobal, only : ib, ie, jb, kb, ke
      use modfields, only : thl0, thlm, thlprof
 
      integer i, k
@@ -1019,7 +1018,7 @@ contains
 
 
    subroutine yqi_profile
-     use modglobal, only : ib, ie, jb, je, kb, ke
+     use modglobal, only : ie, jb, kb, ke
      use modfields, only : qt0, qtm, qtprof
 
      integer i, k
@@ -1035,7 +1034,7 @@ contains
 
 
    subroutine ysi_profile
-     use modglobal, only : ib, ie, jb, je, kb, ke, nsv, ihc
+     use modglobal, only : ib, ie, jb, kb, ke, nsv, ihc
      use modfields, only : sv0, svm, svprof
 
      integer i, k, n, m
@@ -1056,12 +1055,12 @@ contains
 
    subroutine ymo_convective
      use modglobal,      only : je, dyi, rk3step, dt
-     use modfields,      only : u0, um, v0, vm, w0, wm, e120, e12m, vouttot
+     use modfields,      only : u0, um, w0, wm, e120, e12m, vouttot
      use modsubgriddata, only : loneeqn
 
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      ! change to vouttot
      u0(:, je + 1, :) = u0(:, je + 1, :) - (u0(:, je + 1, :) - u0(:, je, :))*dyi*rk3coef*vouttot
@@ -1080,11 +1079,11 @@ contains
    subroutine yTo_convective
 
      use modglobal, only : je, dyi, rk3step, dt
-     use modfields, only : thl0, thlm, v0, vouttot
+     use modfields, only : thl0, thlm, vouttot
 
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      thl0(:, je + 1, :) = thl0(:, je + 1, :) - (thl0(:, je + 1, :) - thl0(:, je, :))*dyi*rk3coef*vouttot
      thlm(:, je + 1, :) = thlm(:, je + 1, :) - (thlm(:, je + 1, :) - thlm(:, je, :))*dyi*rk3coef*vouttot
@@ -1095,10 +1094,10 @@ contains
    subroutine yqo_convective
 
      use modglobal, only : je, dyi, rk3step, dt
-     use modfields, only : qt0, qtm, v0, vouttot
+     use modfields, only : qt0, qtm, vouttot
 
      real rk3coef
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      qt0(:, je + 1, :) = qt0(:, je + 1, :) - (qt0(:, je + 1, :) - qt0(:, je, :))*dyi*rk3coef*vouttot
      qtm(:, je + 1, :) = qtm(:, je + 1, :) - (qtm(:, je + 1, :) - qtm(:, je, :))*dyi*rk3coef*vouttot
@@ -1109,12 +1108,12 @@ contains
    subroutine yso_convective
 
      use modglobal, only : je, rk3step, dt, dyi, nsv
-     use modfields, only :sv0, svm, v0, vouttot
+     use modfields, only :sv0, svm, vouttot
 
      real rk3coef
      integer n
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        sv0(:, je + 1, :, n) = sv0(:, je + 1, :, n) - (sv0(:, je + 1, :, n) - sv0(:, je, :, n))*dyi*rk3coef*vouttot
@@ -1126,13 +1125,13 @@ contains
 
    subroutine yso_Neumann
 
-     use modglobal, only : je, jhc, rk3step, dt, dyi, nsv
+     use modglobal, only : je, jhc, rk3step, dt, nsv
      use modfields, only : sv0, svm
 
      real rk3coef
      integer n, m
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        do m = 1, jhc
@@ -1147,13 +1146,13 @@ contains
    !>set boundary conditions pup,pvp,pwp in subroutine fillps in modpois.f90
    subroutine bcpup(pup, pvp, pwp, rk3coef)
 
-     use modglobal,    only : ib, ie, jb, je, ih, jh, kb, ke, kh, rk3step, dxi, dyi, dzhi, &
+     use modglobal,    only : ib, ie, jb, je, ih, jh, kb, ke, kh, dxi, dyi, dzhi, &
                               ibrank, ierank, jbrank, jerank, BCxm, BCym, BCtopm, &
                               BCtopm_freeslip, BCtopm_noslip, BCtopm_pressure, &
                               BCxm_periodic, BCxm_profile, BCxm_driver, &
                               BCym_periodic, BCym_profile
-     use modfields,    only : pres0, up, vp, wp, um, vm, wm, w0, u0, v0, uouttot, vouttot, uinit, vinit, uprof, vprof, pres0, IIc, IIcs
-     use modmpi,       only : excjs, excis, myid, avexy_ibm
+     use modfields,    only : pres0, up, vp, wp, um, vm, wm, u0, v0, uouttot, vouttot, uprof, vprof, pres0, IIc, IIcs
+     use modmpi,       only : excjs, excis, avexy_ibm
      use modinletdata, only : u0driver
      use decomp_2d,    only : exchange_halo_z
 
@@ -1189,7 +1188,7 @@ contains
        end do
 
      case(BCtopm_pressure)
-       call avexy_ibm(pres0ij(kb:ke+kh),pres0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+       call avexy_ibm(pres0ij(kb:ke+kh),pres0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
 
        do j = jb, je
          do i = ib, ie
@@ -1300,9 +1299,9 @@ contains
    !>set pressure boundary conditions
    subroutine bcp(p)
 
-     use modglobal, only : ib, ie, jb, je, ih, jh, kb, ke, kh, dyi, rk3step, dt, &
+     use modglobal, only : ib, ie, jb, je, ih, jh, kb, ke, kh, rk3step, dt, &
                            ibrank, ierank, jbrank, jerank, BCxm, BCym, BCxm_periodic, BCym_periodic
-     use modfields, only : pres0, up, u0, um, uouttot, vp, v0
+     use modfields, only : pres0
      use decomp_2d, only : exchange_halo_z
 
      real, dimension(ib - ih:ie + ih, jb - jh:je + jh, kb - kh:ke + kh), intent(inout) :: p !< pressure
@@ -1312,7 +1311,7 @@ contains
      if (rk3step == 0) then ! dt not defined yet
        rk3coef = 1.
      else
-       rk3coef = dt / (4. - dble(rk3step))
+       rk3coef = dt / (4. - real(rk3step))
      end if
      rk3coefi = 1. / rk3coef
 
@@ -1402,9 +1401,8 @@ contains
    !! to infinity at the bottom of the sponge layer.
    !! \endlatexonly
    subroutine grwdamp
-      use modglobal, only:ke, kmax, lcoriol, igrw_damp, geodamptime
+      use modglobal, only:ke, lcoriol, igrw_damp, geodamptime
       use modfields, only:up, vp, wp, thlp, qtp, u0, v0, w0, thl0, qt0, ug, vg, thl0av, qt0av, u0av, v0av
-      use modmpi, only:myid
       implicit none
 
       integer k
@@ -1450,7 +1448,7 @@ contains
 
 
    subroutine fluxtop(field, ek, flux)
-      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, dzf, dzh, dzhi, eps1
+      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, dzf, eps1, dzh, dzhi
 
       real, intent(inout) :: field(ib - ih:ie + ih, jb - jh:je + jh, kb - kh:ke + kh)
       real, intent(in)    ::    ek(ib - ih:ie + ih, jb - jh:je + jh, kb - kh:ke + kh)
@@ -1465,8 +1463,7 @@ contains
    end subroutine fluxtop
 
    subroutine valuetop(field, val)
-      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, dzh, dzf, dzhi, dzfi
-      use modmpi, only : myid
+      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh
       real, intent(inout) :: field(ib - ih:ie + ih, jb - jh:je + jh, kb - kh:ke + kh)
       real, intent(in)    :: val
 
@@ -1478,7 +1475,7 @@ contains
    end subroutine valuetop
 
    subroutine fluxtopscal(flux)
-      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, dzf, dzh, dzhi, nsv, khc
+      use modglobal, only:ib, ie, ih, jb, je, jh, ke, dzf, dzh, dzhi, nsv, khc
       use modfields, only:sv0, svm
       use modsubgriddata, only:ekh
 
@@ -1496,7 +1493,7 @@ contains
    end subroutine fluxtopscal
 
    subroutine valuetopscal(val)
-      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, eps1, nsv, khc
+      use modglobal, only:ke, nsv, khc
       use modfields, only:sv0, svm
       real, intent(in)    :: val(1:nsv)
       integer :: m, n
@@ -1517,7 +1514,7 @@ contains
    subroutine tqaver
 
       use modmpi, only:comm3d, mpierr, my_real, mpi_sum
-      use modglobal, only:ib, ie, jb, je, ih, jh, kb, ke, nsv, rslabs
+      use modglobal, only:ib, ie, jb, je, ke, nsv, rslabs
       use modfields, only:thl0, qt0, sv0
       implicit none
 

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -74,7 +74,7 @@ contains
   end subroutine initchecksim
 !>Run checksim. Timekeeping, and output
   subroutine checksim
-    use modglobal, only : timee, rk3step, dt_lim,dt
+    use modglobal, only : timee, rk3step, dt
     use modmpi,    only : myid
     implicit none
     character(20) :: timeday
@@ -98,7 +98,7 @@ contains
   end subroutine checksim
 !>      Calculates the courant number as in max(w)*deltat/deltaz
   subroutine calccourant
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxhi,dyi,dzhi,dt,timee
+    use modglobal, only : ib,ie,jb,je,kb,ke,dxhi,dyi,dzhi
     use modfields, only : um,vm,wm
     use modmpi,    only : myid,comm3d,mpierr,mpi_max,my_real
     implicit none
@@ -128,7 +128,7 @@ contains
 !> Calculates the diffusion number as max(ekm) *deltat/deltax**2
   subroutine calcdiffnr
 
-    use modglobal,      only : ib,ie,jb,je,kb,ke,kh,dxh2i,dy2i,dzh,dt,timee
+    use modglobal,      only : ib,ie,jb,je,kb,ke,dxh2i,dy2i,dzh
     use modsubgriddata, only : ekm,ekh
     use modmpi,         only : myid,comm3d,mpierr,mpi_max,my_real
     implicit none
@@ -163,8 +163,8 @@ contains
 
     use modglobal, only : ib,ie,jb,je,ke,kb,dy,dxh,dzh
     use modfields, only : u0,v0,w0
-    use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,my_real,mpierr
-    use modsubgriddata, only : ekm,ekh
+    use modmpi,    only : myid,comm3d,mpi_max,my_real,mpierr
+    use modsubgriddata, only : ekm
     implicit none
 
     real reyntotl,reyntot

--- a/src/modchem.f90
+++ b/src/modchem.f90
@@ -27,8 +27,8 @@ save
 
 contains
     subroutine chem
-    use modglobal,  only : lchem,k1,JNO2,dt,rk3step,ib,ie,ihc,ih,jb,je,jhc,jh,kb,ke,khc,kh
-    use modfields,  only : svp,svm,sv0,IIc
+    use modglobal,  only : lchem,k1,JNO2,dt,rk3step,ib,ie,ihc,jb,je,jhc,kb,ke,khc
+    use modfields,  only : sv0,IIc
     implicit none
     real, dimension(ib-ihc:ie+ihc,jb-jhc:je+jhc,kb:ke+khc)     :: dummyNO, dummyNO2, dummyO3
 

--- a/src/modfielddump.f90
+++ b/src/modfielddump.f90
@@ -35,7 +35,7 @@ module modfielddump
   PUBLIC :: initfielddump, fielddump,exitfielddump
   save
   !NetCDF variables
-  integer :: ncid,ncid1,ncid2,nrec = 0
+  integer :: ncid,nrec = 0
 !  real, pointer :: point
   type domainptr
     real, pointer :: point(:,:,:)
@@ -43,12 +43,8 @@ module modfielddump
   type(domainptr), dimension(30) :: pfields
 
   character(80) :: fname = 'fielddump.xxx.xxx.xxx.nc'
-  character(80) :: fname1 = 'fielddump.xxx.xxx.xxx.1.nc'
-  character(80) :: fname2 = 'fielddump.xxx.xxx.xxx.2.nc'
   !dimension(nvar,4) :: ncname
   character(80),dimension(1,4) :: tncname
-  character(80),dimension(1,4) :: tncname1
-  character(80),dimension(1,4) :: tncname2
 
   integer :: ilow,ihigh,jlow,jhigh,klow,khigh,nvar
   logical :: ldiracc   = .false. !< switch for doing direct access writing (on/off)
@@ -58,11 +54,10 @@ module modfielddump
 contains
  !> Initializing fielddump. Read out the namelist, initializing the variables
   subroutine initfielddump
-    use modmpi,   only   :myid,my_real,mpierr,comm3d,mpi_logical,mpi_integer,cmyidx,cmyidy,mpi_character
-    use modglobal,only   :imax,jmax,kmax,imax1,jmax1,kmax1,imax2,jmax2,kmax2,cexpnr,ifnamopt,fname_options,dtmax,kb,ke, ladaptive,dt_lim,btime,nsv,fieldvars,ib,ie,jb,je,kb,ke, ih,jh,lfielddump,ktot,kh
+    use modmpi,   only   :mpierr,comm3d,mpi_logical,mpi_integer,cmyidx,cmyidy,mpi_character
+    use modglobal,only   :cexpnr,kb,ke,fieldvars,ib,ie,jb,je,kb,ke, ih,jh,lfielddump,kh
     use modstat_nc,only  : open_nc, define_nc,ncinfo,writestat_dims_nc
-    use modfields, only  : u0,v0,w0,thl0,sv0,ql0,qt0,pres0,div,dudx,dvdy,dwdz,ru,rv,rw,tau_x, tau_y, tau_z, thl_flux
-    use modpois, only : p, pup,pvp,pwp, rhs, dpupdx, dpvpdy, dpwpdz, xyzrt, Fxy, Fxyz
+    use modfields, only  : u0,v0,w0,thl0,sv0,ql0,qt0,pres0,div,tau_x, tau_y, tau_z, thl_flux
     use modibm, only : mask_u, mask_v, mask_w, mask_c
     implicit none
     integer :: ierr, n
@@ -383,19 +378,16 @@ contains
 
   !> Do fielddump. Collect data to truncated (2 byte) integers, and write them to file
   subroutine fielddump
-    use modfields, only : u0,v0,w0,thl0,qt0,ql0,sv0,pres0,u01,u02,u0h,um,div,dudx,dvdy,dwdz,tau_x  !ILS13 21.04.2015 changed to u0 from um  etc
-    use modsurfdata,only : thls,qts,thvs
-    use modglobal, only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,timee,dt_lim,cexpnr,ifoutput,imax,jmax,&
-                          tfielddump, tnextfielddump,nsv, lfielddump, ktot,fieldvars, imax1,jmax1,kmax1,imax2,jmax2,kmax2,rk3step,dyi,dxfi,dzhi
+    use modfields, only : u0,v0,w0,div,dudx,dvdy,dwdz  !ILS13 21.04.2015 changed to u0 from um  etc
+    use modglobal, only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,timee,&
+                          tfielddump, tnextfielddump, lfielddump, rk3step,dyi,dxfi,dzhi
     !use modmpi,    only : myid,cmyid
     !use modsubgriddata, only : ekm,sbshr
     use modstat_nc, only : writestat_nc
-    use modmpi, only : myid,cmyid
     implicit none
 
-    real, allocatable :: vars(:,:,:,:), vars1(:,:,:,:), vars2(:,:,:,:)
+    real, allocatable :: vars(:,:,:,:)
     integer i,j,k,n
-    integer :: writecounter = 1
 
     if (.not. ((timee>=tnextfielddump) .or. (rk3step==0))) return
 

--- a/src/modfields.f90
+++ b/src/modfields.f90
@@ -439,7 +439,7 @@ contains
   subroutine initfields
 
     use modglobal, only : ib,ie,jb,je,ih,jh,kb,ke,kh,jtot,nsv,&
-         ihc,jhc,khc,ltdump,lmintdump,lytdump,lxytdump,ltkedump,ltempeq,lmoist,lchem,lscasrcr,ltreedump!, iadv_kappa,iadv_sv
+         ihc,jhc,khc,ltdump,lmintdump,lytdump,lxytdump,ltkedump,lscasrcr,ltreedump!, iadv_kappa,iadv_sv
     use decomp_2d, only : alloc_z
     ! Allocation of prognostic variables
     implicit none

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -64,15 +64,11 @@ module modforces
     !-----------------------------------------------------------------|
 
     !  use modglobal, only : i1,j1,kmax,dzh,dzf,grav
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzhi,dzf,grav,lbuoyancy
-    use modfields, only : u0,v0,w0,up,vp,wp,thv0h,dpdxl,dpdyl,thlp,thlpcar,thvh
-    use modibmdata, only : nxwallsnorm, xwallsnorm
-    use modsurfdata,only : thvs
-    use modmpi, only : myid
+    use modglobal, only : ib,ie,jb,je,kb,ke,grav,lbuoyancy
+    use modfields, only : up,vp,wp,thv0h,dpdxl,dpdyl,thlp,thlpcar,thvh
     implicit none
 
-    real thvsi
-    integer i, j, k, n, jm, jp, km, kp
+    integer i, j, k, jm, jp
 
 
     if (lbuoyancy ) then
@@ -137,15 +133,10 @@ module modforces
   end subroutine forces
 
   subroutine detfreestream(freestream)
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxf,xh,dt,&
-                          Uinf,Vinf,lvinf,dy
-    use modfields, only : u0,dpdxl,dgdt,dpdx,v0,u0av,v0av
-    use modmpi, only    : myid,comm3d,mpierr,mpi_sum,my_real,nprocs
+    use modglobal, only : ke,lvinf
+    use modfields, only : u0av,v0av
     implicit none
     real, intent(out) :: freestream
-
-    real  utop,vtop,dum
-    integer i,j
 
     if (lvinf) then
         freestream = v0av(ke)
@@ -156,10 +147,9 @@ module modforces
   end subroutine detfreestream
 
   subroutine detfreestrtmp(freestrtmp)
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxf,xh,dt,&
-                          Uinf
-    use modfields, only : thl0,dpdxl,dgdt,dpdx
-    use modmpi, only    : myid,comm3d,mpierr,mpi_sum,my_real,nprocs
+    use modglobal, only : ib,ie,jb,je,ke,dxf,xh
+    use modfields, only : thl0
+    use modmpi, only    : comm3d,mpierr,mpi_sum,my_real,nprocs
     implicit none
 
     real, intent(out) :: freestrtmp
@@ -181,16 +171,13 @@ module modforces
   end subroutine detfreestrtmp
 
   subroutine fixuinf2
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxf,xh,dt,&
-                          Uinf,ifixuinf,tscale,timee,rk3step,inletav,&
-                          freestreamav,freestrtmpav,ltempeq
-    use modsurfdata,only: thl_top
-    use modfields, only : u0,thl0,dpdxl,dgdt,dpdx,thlsrcdt
-    use modmpi, only    : myid,comm3d,mpierr,mpi_sum,my_real,nprocs
+    use modglobal, only : dt,&
+                          Uinf,ifixuinf,tscale,rk3step,inletav,&
+                          freestreamav
+    use modfields, only : dgdt
     implicit none
 
-    real  utop,freestream,freestrtmp,rk3coef
-    integer i,j
+    real  utop,freestream
 
     utop = 0.
 
@@ -230,14 +217,13 @@ module modforces
   end subroutine fixuinf2
 
   subroutine fixuinf1
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxf,xh,dt,&
-                          Uinf,Vinf,ifixuinf,tscale,timee,rk3step,inletav,&
-                          freestreamav,lvinf
-    use modfields, only : u0,dpdxl,dgdt,dpdx,up,vp,u0av,v0av
-    use modmpi, only    : myid,comm3d,mpierr,mpi_sum,my_real,nprocs
+    use modglobal, only : ib,ie,jb,je,kb,ke,dt,&
+                          Uinf,Vinf,ifixuinf,rk3step,&
+                          lvinf
+    use modfields, only : up,vp,u0av,v0av
     implicit none
 
-    real  utop,freestream,rk3coef
+    real  utop
     integer i,j,k
 
     utop = 0.
@@ -301,16 +287,9 @@ module modforces
   end subroutine fixuinf1
 
   subroutine fixthetainf
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dxf,xh,dt,&
-                          Uinf,ifixuinf,tscale,timee,rk3step,inletav,&
-                          freestreamav,thlsrc,ltempeq
-    use modfields, only : thl0
-    use modmpi, only    : myid,comm3d,mpierr,mpi_sum,my_real,nprocs
-    use modsurfdata, only: thl_top
     implicit none
 
-    real  ttop,freestreamtheta,rk3coef
-    integer i,j
+    real  ttop
 
     ttop = 0.
 
@@ -348,12 +327,12 @@ module modforces
   subroutine masscorr
     !> correct the velocities to get prescribed flow rate
 
-    use modglobal, only : ib,ie,jb,je,ih,jh,kb,ke,kh,dzf,dxf,dy,zh,dt,rk3step,&
+    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzf,dxf,dy,zh,dt,rk3step,&
                           uflowrate,vflowrate,linoutflow,&
                           luoutflowr,lvoutflowr,luvolflowr,lvvolflowr
-    use modfields, only : um,up,vm,vp,uouttot,udef,vouttot,vdef,&
-                          uoutarea,voutarea,fluidvol,IIu,IIv,IIus,IIvs
-    use modmpi,    only : myid,comm3d,mpierr,nprocs,MY_REAL,sumy_ibm,sumx_ibm,avexy_ibm
+    use modfields, only : um,up,vm,vp,uouttot,udef,vdef,&
+                          uoutarea,voutarea,IIu,IIv,IIus,IIvs
+    use modmpi,    only : sumy_ibm,sumx_ibm,avexy_ibm
 
     real, dimension(kb:ke+kh)     :: uvol
     real, dimension(kb:ke+kh)     :: vvol
@@ -370,7 +349,7 @@ module modforces
     integer                       i,j,k
 
     if ((.not.linoutflow) .and. (luoutflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       ! Assumes ie=itot
@@ -412,7 +391,7 @@ module modforces
       uouttot = sum(uout(kb:ke))  ! mass flow rate at outlet
 
     elseif ((.not.linoutflow) .and. (luvolflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       udef = 0.
@@ -421,8 +400,8 @@ module modforces
       uvolold = 0.
 
       ! Assumes equidistant grid
-      call avexy_ibm(uvol(kb:ke+kh),up(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
-      call avexy_ibm(uvolold(kb:ke+kh),um(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
+      call avexy_ibm(uvol(kb:ke+kh),up(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
+      call avexy_ibm(uvolold(kb:ke+kh),um(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
 
       ! average over fluid volume
       uoutflow = rk3coef*sum(uvol(kb:ke)*dzf(kb:ke)) / zh(ke+1)
@@ -442,7 +421,7 @@ module modforces
     end if
 
     if ((.not.linoutflow) .and. (lvoutflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       ! Assumes je=jtot
@@ -486,7 +465,7 @@ module modforces
       end do
 
     elseif ((.not.linoutflow) .and. (lvvolflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       vdef = 0.
@@ -495,8 +474,8 @@ module modforces
       vvolold = 0.
 
       ! Assumes equidistant grid
-      call avexy_ibm(vvol(kb:ke+kh),vp(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
-      call avexy_ibm(vvolold(kb:ke+kh),vm(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
+      call avexy_ibm(vvol(kb:ke+kh),vp(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
+      call avexy_ibm(vvolold(kb:ke+kh),vm(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
 
       ! average over fluid volume
       voutflow = rk3coef*sum(vvol(kb:ke)*dzf(kb:ke)) / zh(ke+1)
@@ -519,7 +498,7 @@ module modforces
   subroutine uoutletarea(area)
     ! calculates outlet area of domain for u-velocity excluding blocks
 
-    use modglobal, only   : ib,ie,jb,je,kb,ke,dy,dzf,ierank
+    use modglobal, only   : ie,jb,je,kb,ke,dy,dzf
     use modfields, only   : IIc
     use modmpi, only      : sumy_ibm
 
@@ -544,7 +523,7 @@ module modforces
   subroutine voutletarea(area)
     ! calculates outlet area of domain for v-velocity excluding blocks
 
-    use modglobal, only : ib,ie,jb,je,kb,ke,dxf,dzf,jerank
+    use modglobal, only : ib,ie,je,kb,ke,dxf,dzf
     use modfields, only : IIc
     use modmpi,    only : sumx_ibm
 
@@ -569,7 +548,7 @@ module modforces
   subroutine fluidvolume(volume)
     ! calculates fluid volume of domain excluding blocks
 
-    use modglobal, only   : ib,ie,ih,jb,je,jh,kb,ke,kh,dy,dxf,dzf
+    use modglobal, only   : ib,ie,jb,je,kb,ke,kh,dy,dxf,dzf
     use modfields, only   : IIc, IIcs
     use modmpi, only      : sumy_ibm, avexy_ibm
 
@@ -577,7 +556,6 @@ module modforces
     real, intent(out)             :: volume
     real, dimension(ib:ie,kb:ke)  :: sumy
     real, dimension(kb:ke+kh)        :: sumxy
-    integer                          k
 
     sumy = 0.
     sumxy = 0.
@@ -591,7 +569,7 @@ module modforces
     ! end do
 
     ! Equidistant x
-    call avexy_ibm(sumxy(kb:ke+kh),IIc(ib:ie,jb:je,kb:ke+kh)*dxf(1)*dy,ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+    call avexy_ibm(sumxy(kb:ke+kh),IIc(ib:ie,jb:je,kb:ke+kh)*dxf(1)*dy,ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
 
     ! integrate fluid area in z
     volume = sum(sumxy(kb:ke)*dzf(kb:ke))
@@ -637,9 +615,8 @@ module modforces
     !-----------------------------------------------------------------|
 
     ! use modglobal, only : i1,j1,kmax,dzh,dzf,om22,om23
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzh,dzf,om22,om23,lcoriol,lprofforc,timee
-    use modfields, only : u0,v0,w0,up,vp,wp,ug,vg
-    use modmpi, only : myid
+    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzh,dzf,om22,om23,lcoriol,lprofforc
+    use modfields, only : u0,v0,w0,up,vp,wp,ug
     implicit none
 
     integer i, j, k, jm, jp, km, kp
@@ -759,11 +736,10 @@ module modforces
     !                                                                 |
     !-----------------------------------------------------------------|
 
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzh,nsv,lmomsubs
+    use modglobal, only : ib,ie,jb,je,kb,ke,dzh,nsv,lmomsubs
     use modfields, only : up,vp,thlp,qtp,svp,&
                           whls, u0av,v0av,thl0av,qt0av,sv0av,&
                           dudxls,dudyls,dvdxls,dvdyls,dthldxls,dthldyls,dqtdxls,dqtdyls,dqtdtls
-    use modmpi, only: myid
     implicit none
 
     integer k,n
@@ -847,9 +823,8 @@ module modforces
   end subroutine lstend
 
   subroutine nudge
-    use modglobal,  only : kb,ke,lmoist,ltempeq,lnudge,lnudgevel,tnudge,nnudge,numol,nsv
+    use modglobal,  only : kb,ke,lmoist,ltempeq,lnudge,lnudgevel,tnudge,nnudge,nsv
     use modfields,  only : thlp,qtp,svp,sv0av,thl0av,qt0av,up,vp,u0av,v0av,uprof,vprof,thlprof,qtprof,svprof
-    use modmpi,     only : myid
     implicit none
     integer :: k, n
 
@@ -890,13 +865,13 @@ module modforces
   ! use initfac, only :  max_height_index
   use modfields, only : thlp, qtp
   !use modglobal, only: ltempeq, lperiodicEBcorr, ib, ie, jb, je, kb, ke, imax, jtot
-  use modglobal, only : ltempeq, lmoist, lperiodicEBcorr, ib, ie, jb, je, kb, ke,&
+  use modglobal, only : ltempeq, lmoist, lperiodicEBcorr, ib, ie, jb, je, ke,&
                           itot, jtot, totheatflux,sinkbase, totqflux, &
-                          zh, dx, dy ,dzh, fraction
-  use modmpi, only : comm3d, mpierr, MY_REAL, myid, MPI_SUM
+                          zh, fraction
+  use modmpi, only : comm3d, mpierr, MY_REAL, MPI_SUM
   !
-  integer :: i, j, k, n, M
-  real :: tot_Tflux, tot_qflux, sensible_heat_out, latent_heat_out,R_theta,R_q, H_proj, E_proj, R_theta_scaled,R_q_scaled, abl_height,phi_theta_t,phi_q_t  !, !tot_qflux !, sink_points
+  integer :: i, j, k, M
+  real :: tot_Tflux, tot_qflux, latent_heat_out,R_theta,R_q, H_proj, E_proj, R_theta_scaled,R_q_scaled, abl_height,phi_theta_t,phi_q_t  !, !tot_qflux !, sink_points
   !
   !write(*,*) 'lperiodicEBcorr ', lperiodicEBcorr
   !write(*,*) 'fraction', fraction
@@ -975,14 +950,14 @@ module modforces
   subroutine shiftedPBCs
       ! Nudge the flow in a region near the outlet
       use modglobal, only : ib, itot, ie, jb, je, kb, ke, xh, ds, dyi, xlen, rk3step, dt, pi
-      use modfields, only : u0, v0, w0, u0av, up, vp, wp, vm
+      use modfields, only : u0, v0, w0, u0av, up, vp, wp
       use decomp_2d, only : zstart
 
       integer :: i, j, k, ig
-      real :: vs, RHS, rk3coef
+      real :: vs, rk3coef
 
       if (ds > 0) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       do i = ib,ie
          ig = i + zstart(1) - 1 ! global i position
          if (ig > int(itot/2)) then

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -509,7 +509,7 @@ contains
    !!
    !! Set courant number, calculate the grid sizes (both computational and physical), and set the coriolis parameter
    subroutine initglobal
-      use modmpi,   only : myid, comm3d, my_real, mpierr
+      use modmpi,   only : comm3d, my_real, mpierr
       use decomp_2d
       implicit none
 

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -611,10 +611,10 @@ subroutine excjs(a,sx,ex,sy,ey,sz,ez,ih,jh)
     return
   end subroutine slabsum
 
-  subroutine avexy_ibm(aver,var,ib,ie,jb,je,kb,ke,ih,jh,kh,II,IIs,lnan)
+  subroutine avexy_ibm(aver,var,ib,ie,jb,je,kb,ke,kh,II,IIs,lnan)
     implicit none
 
-    integer :: ib,ie,jb,je,kb,ke,ih,jh,kh
+    integer :: ib,ie,jb,je,kb,ke,kh
     real    :: aver(kb:ke+kh)
     real    :: var(ib:ie,jb:je,kb:ke+kh)
     integer :: II(ib:ie,jb:je,kb:ke+kh)
@@ -689,7 +689,6 @@ subroutine excjs(a,sx,ex,sy,ey,sz,ez,ih,jh)
   real                    :: var(ib:ie,jb:je,kb:ke)
   integer                 :: II(ib:ie,jb:je,kb:ke)
   integer                 :: IIt(ib:ie,kb:ke)
-  logical                 :: lytdump,lnan
 
   avero = 0.
   aver  = 0.

--- a/src/modpurifiers.f90
+++ b/src/modpurifiers.f90
@@ -61,7 +61,7 @@ contains
       end subroutine createpurifiers
 
       subroutine purifiers
-      use modglobal,  only : ib,ie,jb,je,kb,ke,ih,xf,xh,zh,purif,npurif,lpurif,itot,jtot,Qpu,epu,dy,nsv
+      use modglobal,  only : ib,ie,jb,je,xh,zh,purif,npurif,lpurif,itot,jtot,Qpu,epu,dy,nsv
       use modfields,  only : um,vm,wm,u0,v0,w0,up,vp,wp,svp,svm,sv0
       use modmpi,     only : myidx,myidy,nprocx,nprocy
 

--- a/src/modsave.f90
+++ b/src/modsave.f90
@@ -39,32 +39,19 @@ contains
 
     use mpi
 
-    use modsurfdata,only: ustar,thlflux,qtflux,svflux,dudz,dvdz,dthldz,dqtdz,ps,thls,qts,thvs,oblav
-
-    use modfields, only : u0,v0,w0,thl0,qt0,ql0,ql0h,e120,dthvdz,presf,presh,sv0,mindist,wall,&
-                          uav,vav,wav,uuav,vvav,wwav,uvav,uwav,vwav,thlav,thl2av,qtav,qlav,ql2av,qt2av,svav,sv2av,momthick,&
-                          friction,displthick,pres0,viscratioav,thluav,thlvav,thlwav,qtuav,qtvav,qtwav,qluav,qlvav,qlwav,svuav,svvav,svwav,&
-                          upupav,vpvpav,wpwpav,thlpthlpav,qlpqlpav,qtpqtpav,svpsvpav,upvpav,upwpav,vpwpav,thlpupav,thlpvpav,&
-                          thlpwpav,qlpupav,qlpvpav,qlpwpav,qtpupav,qtpvpav,qtpwpav,svpupav,svpvpav,svpwpav,presav,&
-                          uusgsav,vvsgsav,wwsgsav,uwsgsav,thlusgsav,thlwsgsav,qlusgsav,qlwsgsav,qtusgsav,qtwsgsav,svusgsav,svwsgsav,tkesgsav,&
-                          strain2av,disssgsav,t_vav,tvmx,tvmy,tvmz,tsgsmx1,tsgsmx2,tsgsmy1,tsgsmy2,tsgsmz1,&
-                          tsgsmz2,t_sgsav,nusgsav,tpm,t_pav,ttmx,ttmy,ttmz,t_tav,p_bav,d_sgsav,p_tav,tkeadv
-    use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,trestart,tnextrestart,dt_lim,timee,btime,xh,&
-                          cexpnr,ntimee,rk3step,ifoutput,nsv,timeleft,dt,ntrun,totavtime,&
-                          iinletgen,timee,runavtime,inletav,totinletav,linletRA,ltempeq,lmoist,&
-                          dzf,dzfi,dzhi,dxf,dxfi,dyi,dxhi,nstore,numol,dy2i,grav,libm,jmax,nblocks
-    use modmpi,    only : cmyid,cmyidx,cmyidy,myid,slabsum,excjs,comm3d
+    use modfields, only : u0,v0,w0,thl0,qt0,ql0,ql0h,e120,sv0,mindist,wall,&
+                          pres0
+    use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,trestart,tnextrestart,timee,&
+                          cexpnr,rk3step,ifoutput,nsv,dt,ntrun,&
+                          iinletgen,timee,nstore
+    use modmpi,    only : cmyidx,cmyidy,myid,slabsum,excjs,comm3d
     use modsubgriddata, only : ekm
-    use modibmdata,   only  : ibmxforcevol
-    use initfac , only : block
-    use modinletdata, only   : Urec,Wrec,Uinl,Utav,QLinl,QTinl,QLrec,QTrec,QTtav,QLtav,Ttav,upupavinl,vpvpavinl,wpwpavinl,upwpavinl,&
-                               thlpthlpavinl,thlpupavinl,thlpwpavinl,qlpqlpavinl,qlpupavinl,qlpwpavinl,qtpqtpavinl,qtpupavinl,qtpwpavinl,Tinl,Trec,nstepread
+    use modinletdata, only   : nstepread
 
     implicit none
     logical :: lexitnow = .false.
-    integer imin,ihour
-    integer i,j,k,n,im,ip,jm,jp,jpp,km,kp,kpp,il,iu,jl,ju,kl,ku
-    character(25) name,name2,name3,name4,linkname
+    integer i,j,k,n
+    character(25) name
     integer :: ierr, err_code
 
     if (timee == 0) return

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -61,29 +61,28 @@ module modstartup
                                     nsv, itot, jtot, ktot, xlen, ylen, xlat, xlon, xday, xtime, lwalldist, &
                                     lmoist, lcoriol, igrw_damp, geodamptime, ifnamopt, fname_options, &
                                     nscasrc,nscasrcl,iwallmom,iwalltemp,iwallmoist,iwallscal,ipoiss,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,diffnr,ladaptive,author,&
-                                    linoutflow, lper2inout, libm, lnudge, lnudgevel, tnudge, nnudge, lles, luoutflowr, lvoutflowr, luvolflowr, lvvolflowr, &
+                                    lper2inout, libm, lnudge, lnudgevel, tnudge, nnudge, lles, luoutflowr, lvoutflowr, luvolflowr, lvvolflowr, &
                                     uflowrate, vflowrate, lstoreplane, iplane, &
-                                    lreadmean, iinletgen, inletav, lreadminl, Uinf, Vinf, linletRA, nblocks, &
-                                    lscalrec,lSIRANEinout,lscasrc,lscasrcl,lscasrcr,lydump,lytdump,lxydump,lxytdump,ltdump,lmintdump,ltkedump,lzerogradtop,&
+                                    lreadmean, inletav, lreadminl, Uinf, Vinf, linletRA, nblocks, &
+                                    lscasrc,lscasrcl,lscasrcr,lydump,lytdump,lxydump,lxytdump,ltdump,lmintdump,ltkedump,&
                                     lkslicedump,lislicedump,ljslicedump,kslice,islice,jslice,&
-                                    lzerogradtopscal, lbuoyancy, ltempeq, &
+                                    lbuoyancy, ltempeq, &
                                     lfixinlet, lfixutauin, pi, &
-                                    thlsrc, ifixuinf, lvinf, tscale, ltempinout, lmoistinout,  &
+                                    thlsrc, ifixuinf, lvinf, tscale,  &
                                     lwallfunc,lprofforc,lchem,k1,JNO2,rv,rd,tnextEB,tEB,dtEB,bldT,flrT, lperiodicEBcorr, fraction,sinkbase,wsoil,wgrmax,wwilt,wfc,skyLW,GRLAI,rsmin,nfcts,lEB,lwriteEBfiles,nfaclyrs,lconstW,lvfsparse,nnz,lfacTlyrs, &
                                     BCxm,BCxT,BCxq,BCxs,BCym,BCyT,BCyq,BCys,BCzp,ds, &
                                     BCtopm,BCtopT,BCtopq,BCtops,BCbotm,BCbotT,BCbotq,BCbots, &
-                                    BCxm_periodic, BCym_periodic, &
                                     idriver,tdriverstart,driverjobnr,dtdriver,driverstore,lchunkread,chunkread_size, &
                                     lrandomize, prandtlturb, fkar, lwritefac, dtfac, tfac, tnextfac, &
                                     ltrees,ntrees,Qstar,dQdt,lad,lsize,r_s,cd,dec,ud,ltreedump, &
                                     lpurif,npurif,Qpu,epu
       use modsurfdata,       only : z0, z0h,  wtsurf, wttop, wqtop, wqsurf, wsvsurf, wsvtop, wsvsurfdum, wsvtopdum, ps, thvs, thls, thl_top, qt_top, qts
-      use modfields,         only : initfields, dpdx, ncname
+      use modfields,         only : initfields, dpdx
       use modpois,           only : initpois
       use modboundary,       only : initboundary, ksp
-      use modthermodynamics, only : initthermodynamics, lqlnr, chi_half
+      use modthermodynamics, only : initthermodynamics, lqlnr
       use modsubgrid,        only : initsubgrid
-      use modmpi,            only : comm3d, myid, myidx, myidy, cmyid, cmyidx, cmyidy, mpi_integer, mpi_logical, my_real, mpierr, mpi_character, nprocx, nprocy, nbreast, nbrwest, nbrnorth, nbrsouth
+      use modmpi,            only : comm3d, myid, mpi_integer, mpi_logical, my_real, mpierr, mpi_character, nprocx, nprocy
       use modinlet,          only : initinlet
       use modinletdata,      only : di, dr, di_test, dti, iangledeg, iangle
       use modibmdata,        only : bctfxm, bctfxp, bctfym, bctfyp, bctfz, bcqfxm, bcqfxp, bcqfym, bcqfyp, bcqfz
@@ -99,8 +98,6 @@ module modstartup
 
       implicit none
       integer :: ierr
-      logical, dimension(3) :: periodic_bc
-      integer, dimension(2) :: myids
 
       !declare namelists
 
@@ -688,25 +685,23 @@ module modstartup
       !                                                                 |
       !-----------------------------------------------------------------|
 
-      use modsurfdata, only : wtsurf, wqsurf, qts, ps
-      use modglobal,   only : itot,ktot,jtot,ylen,xlen,ib,ie,dtmax,runtime, &
+      use modsurfdata, only : ps
+      use modglobal,   only : itot,ktot,jtot,ylen,xlen,dtmax,runtime, &
                               startfile,lwarmstart,lstratstart,lmoist, nsv, &
-                              BCxm, BCxT, BCxq, BCxs, BCym, BCyT, BCyq, BCys, BCtopm, BCbotm, &
+                              BCxm, BCxT, BCxq, BCxs, BCym, BCyT, BCyq, BCtopm, BCbotm, &
                               BCbotm_wfneutral, BCtopm_pressure, &
                               BCxm_periodic, BCxT_periodic, BCxq_periodic, &
                               BCxm_profile, BCxT_profile, BCxq_profile, &
                               BCxm_driver, BCxT_driver, BCxq_driver, BCxs_driver, &
-                              BCym_periodic, BCym_profile, BCyT_periodic, BCyT_profile, &
+                              BCym_periodic, BCyT_periodic, BCyT_profile, &
                               BCyq_periodic, BCyq_profile, &
-                              iinletgen,linoutflow,ltempeq,iwalltemp,iwallmom,&
-                              ipoiss,POISS_FFT2D,POISS_FFT3D,POISS_CYC,&
+                              linoutflow,ltempeq,iwalltemp,iwallmom,&
+                              ipoiss,POISS_FFT2D,&
                               lydump,lytdump,luoutflowr,lvoutflowr,&
                               lhdriver,lqdriver,lsdriver
       use modmpi,      only : myid, comm3d, mpierr, nprocx, nprocy
       use modglobal,   only : idriver
       implicit none
-      real :: d(1:itot-1)
-      logical :: inequi
 
       if (mod(jtot, nprocy) /= 0) then
          if (myid == 0) then
@@ -904,36 +899,31 @@ module modstartup
    subroutine readinitfiles
       use modfields, only:u0, v0, w0, um, vm, wm, thlm, thl0, thl0h, qtm, qt0, qt0h, uinit, vinit, &
          ql0, ql0h, thv0h, sv0, svm, e12m, e120, &
-         dudxls, dudyls, dvdxls, dvdyls, dthldxls, dthldyls, &
          dqtdxls, dqtdyls, dqtdtls, dpdx, dpdxl, dpdyl, &
          wfls, whls, ug, vg, pgx, pgy, uprof, vprof, thlprof, qtprof, e12prof, svprof, &
-         v0av, u0av, qt0av, ql0av, thl0av, qt0av, sv0av, exnf, exnh, presf, presh, rhof, &
-         thlpcar, uav, thvh, thvf, IIc, IIcs, IIu, IIus, IIv, IIvs, IIw, IIws, u0h, thl0c
+         v0av, u0av, qt0av, thl0av, qt0av, sv0av, &
+         thlpcar, thvh, thvf, IIc, IIcs, IIu, IIus, IIv, IIvs, IIw, IIws, thl0c
             use modglobal,         only : ib,ie,ih,ihc,jb,je,jh,jhc,kb,ke,kh,khc,kmax,dtmax,dt,runtime,timeleft,timee,ntimee,ntrun,btime,dt_lim,nsv,&
-         zf, zh, dzf, dzh, rv, rd, grav, cp, rlv, pref0, om23_gs, jgb, jge, Uinf, Vinf, dy, &
-         rslabs, e12min, dzh, dtheta, dqt, dsv, cexpnr, ifinput, lwarmstart, lstratstart, trestart, numol, &
-         ladaptive, tnextrestart, jmax, imax, xh, xf, linoutflow, lper2inout, iinletgen, lreadminl, &
-         uflowrate, vflowrate,ltempeq, prandtlmoli, freestreamav, &
-         tnextfielddump, tfielddump, tsample, tstatsdump, startfile, lprofforc, lchem, k1, JNO2,&
-         idriver,dtdriver,driverstore,tdriverstart,tdriverstart_cold,tdriverdump,lchunkread,xlen,ylen,itot,jtot,ibrank,ierank,jbrank,jerank,BCxm,BCym,lrandomize,BCxq,BCxs,BCxT, BCyq,BCys,BCyT,BCxm_driver,&
+         zh, dzf, dzh, rv, rd, cp, rlv, om23_gs, jgb, jge, Uinf, &
+         e12min, dzh, cexpnr, ifinput, lwarmstart, lstratstart, trestart, numol, &
+         ladaptive, tnextrestart, linoutflow, lper2inout, iinletgen, lreadminl, &
+         ltempeq, prandtlmoli, &
+         tnextfielddump, tfielddump, startfile, lprofforc,&
+         idriver,dtdriver,driverstore,tdriverstart,tdriverstart_cold,tdriverdump,lchunkread,ibrank,lrandomize,BCxs,&
          tEB,tnextEB,dtEB,BCxs_custom,lEB,lfacTlyrs,tfac,tnextfac,dtfac
       use modsubgriddata, only:ekm, ekh, loneeqn
-      use modsurfdata, only:wtsurf, wqsurf, wsvsurf, &
-         thls, thvs, ps, qts, svs, sv_top
+      use modsurfdata, only:thls, sv_top
       ! use modsurface,        only : surface,dthldz
       use modboundary, only:boundary, tqaver, halos
-      use modmpi, only:slabsum, myid, comm3d, mpierr, my_real, avexy_ibm, myidx, myidy
+      use modmpi, only:slabsum, myid, comm3d, mpierr, my_real, avexy_ibm
       use modthermodynamics, only:thermodynamics, calc_halflev
       use modinletdata, only:Uinl, Urec, Wrec, u0inletbc, v0inletbc, w0inletbc, ubulk, vbulk, irecy, Utav, Ttav, &
          uminletbc, vminletbc, wminletbc, u0inletbcold, v0inletbcold, w0inletbcold, &
          storeu0inletbc, storev0inletbc, storew0inletbc, nstepread, nfile, Tinl, &
-         Trec, tminletbc, t0inletbcold, t0inletbc, storet0inletbc, utaui, ttaui, iangle,&
-         u0driver,umdriver,v0driver,vmdriver,w0driver,e120driver,tdriver,thl0driver,qt0driver,storetdriver,&
-         storeu0driver,storeumdriver,storev0driver,storew0driver,storee120driver,storethl0driver,storeqt0driver,&
-         nstepreaddriver
+         Trec, tminletbc, t0inletbcold, t0inletbc, storet0inletbc, utaui, ttaui
       use modinlet, only:readinletfile
       use moddriver, only: readdriverfile,initdriver,drivergen,readdriverfile_chunk
-      use decomp_2d, only : exchange_halo_z, update_halo, decomp_main
+      use decomp_2d, only : exchange_halo_z, update_halo
 
       integer i, j, k, n
 
@@ -946,10 +936,8 @@ module modstartup
       real, dimension(kb:ke) :: taverager ! recycle plane
       real, dimension(kb:ke) :: taveragei ! inlet plane
       real, dimension(kb:ke + 1) :: waverage
-      real, dimension(kb:ke + 1) :: uprofrot
-      real, dimension(kb:ke + 1) :: vprofrot
       real, dimension(kb:ke+kh)  :: u_init, v_init, thl_init, qt_init
-      real tv, ran, ran1
+      real ran, ran1
 
       character(80) chmess
 
@@ -1043,11 +1031,11 @@ module modstartup
 
          thvh = 0.
          ! call slabsum(thvh,kb,ke,thv0h,ib-ih,ie+ih,jb-jh,je+jh,kb-kh,ke+kh,ib,ie,jb,je,kb,ke) ! redefine halflevel thv using calculated thv
-         call avexy_ibm(thvh(kb:ke+kh),thv0h(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIw(ib:ie,jb:je,kb:ke+kh),IIws(kb:ke+kh),.false.)
+         call avexy_ibm(thvh(kb:ke+kh),thv0h(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIw(ib:ie,jb:je,kb:ke+kh),IIws(kb:ke+kh),.false.)
          ! thvh = thvh/rslabs
 
          thvf = 0.0
-         call avexy_ibm(thvf(kb:ke+kh),thv0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+         call avexy_ibm(thvf(kb:ke+kh),thv0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
          ! call slabsum(thvf,kb,ke,thv0,ib-ih,ie+ih,jb-jh,je+jh,kb-kh,ke+kh,ib,ie,jb,je,kb,ke)
          ! thvf = thvf/rslabs
 
@@ -1584,10 +1572,10 @@ module modstartup
             call readrestartfiles
 
             ! average initial profiles
-            call avexy_ibm(u_init(kb:ke+kh),u0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
-            call avexy_ibm(v_init(kb:ke+kh),v0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
-            call avexy_ibm(thl_init(kb:ke+kh),thl0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
-            call avexy_ibm(qt_init(kb:ke+kh),qt0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+            call avexy_ibm(u_init(kb:ke+kh),u0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
+            call avexy_ibm(v_init(kb:ke+kh),v0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
+            call avexy_ibm(thl_init(kb:ke+kh),thl0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+            call avexy_ibm(qt_init(kb:ke+kh),qt0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
 
             if (myid == 0) then
                ! Read profiles from file (potentially for forcing)
@@ -1734,11 +1722,11 @@ module modstartup
 
             thvh = 0.
             ! call slabsum(thvh,kb,ke,thv0h,ib-ih,ie+ih,jb-jh,je+jh,kb-kh,ke+kh,ib,ie,jb,je,kb,ke) ! redefine halflevel thv using calculated thv
-            call avexy_ibm(thvh(kb:ke+kh),thv0h(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIw(ib:ie,jb:je,kb:ke+kh),IIws(kb:ke+kh),.false.)
+            call avexy_ibm(thvh(kb:ke+kh),thv0h(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIw(ib:ie,jb:je,kb:ke+kh),IIws(kb:ke+kh),.false.)
             ! thvh = thvh/rslabs
 
             thvf = 0.0
-            call avexy_ibm(thvf(kb:ke+kh),thv0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+            call avexy_ibm(thvf(kb:ke+kh),thv0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
             ! call slabsum(thvf,kb,ke,thv0,ib-ih,ie+ih,jb-jh,je+jh,kb-kh,ke+kh,ib,ie,jb,je,kb,ke)
             ! thvf = thvf/rslabs
 
@@ -2002,16 +1990,16 @@ module modstartup
             sv0av = 0.
 
             ! call slabsum(u0av  ,kb,ke+kh,u0(:,:,kb:ke+kh)  ,ib-ih,ie+ih,jb-jh,je+jh,kb,ke+kh,ib,ie,jb,je,kb,ke+kh)
-            call avexy_ibm(u0av(kb:ke+kh),u0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
+            call avexy_ibm(u0av(kb:ke+kh),u0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIu(ib:ie,jb:je,kb:ke+kh),IIus(kb:ke+kh),.false.)
             ! call slabsum(v0av  ,kb,ke+kh,v0(:,:,kb:ke+kh)  ,ib-ih,ie+ih,jb-jh,je+jh,kb,ke+kh,ib,ie,jb,je,kb,ke+kh)
-            call avexy_ibm(v0av(kb:ke+kh),v0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
+            call avexy_ibm(v0av(kb:ke+kh),v0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIv(ib:ie,jb:je,kb:ke+kh),IIvs(kb:ke+kh),.false.)
             ! call slabsum(thl0av,kb,ke+kh,thl0(:,:,kb:ke+kh),ib-ih,ie+ih,jb-jh,je+jh,kb,ke+kh,ib,ie,jb,je,kb,ke+kh)
-            call avexy_ibm(thl0av(kb:ke+kh),thl0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+            call avexy_ibm(thl0av(kb:ke+kh),thl0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
             ! call slabsum(qt0av,kb,ke+kh,qt0(:,:,kb:ke+kh),ib-ih,ie+ih,jb-jh,je+jh,kb,ke+kh,ib,ie,jb,je,kb,ke+kh)
-            call avexy_ibm(qt0av(kb:ke+kh),qt0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
+            call avexy_ibm(qt0av(kb:ke+kh),qt0(ib:ie,jb:je,kb:ke+kh),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+kh),IIcs(kb:ke+kh),.false.)
             do n = 1, nsv
                ! call slabsum(sv0av(kb,n),kb,ke+kh,sv0(ib-ih,jb-jh,kb,n),ib-ih,ie+ih,jb-jh,je+jh,kb,ke+kh,ib,ie,jb,je,kb,ke+kh)
-               call avexy_ibm(sv0av(kb:ke+khc,n),sv0(ib:ie,jb:je,kb:ke+khc,n),ib,ie,jb,je,kb,ke,ih,jh,kh,IIc(ib:ie,jb:je,kb:ke+khc),IIcs(kb:ke+khc),.false.)
+               call avexy_ibm(sv0av(kb:ke+khc,n),sv0(ib:ie,jb:je,kb:ke+khc,n),ib,ie,jb,je,kb,ke,kh,IIc(ib:ie,jb:je,kb:ke+khc),IIcs(kb:ke+khc),.false.)
             end do
 
             ! CvH - only do this for fixed timestepping. In adaptive dt comes from restartfile
@@ -2135,15 +2123,14 @@ module modstartup
 
    subroutine readrestartfiles
 
-      use modsurfdata, only:ustar, thlflux, qtflux, svflux, dudz, dvdz, dthldz, dqtdz, ps, thls, qts, thvs, oblav, &
-         wtsurf
-      use modfields, only:u0, v0, w0, thl0, qt0, ql0, ql0h, qtav, qlav, e120, dthvdz, presf, presh, sv0, mindist, wall, &
-         uav, vav, wav, uuav, vvav, wwav, uvav, uwav, vwav, svav, thlav, thl2av, sv2av, pres0, svm, &
+      use modsurfdata, only:thls
+      use modfields, only:u0, v0, w0, thl0, qt0, ql0, ql0h, qtav, qlav, e120, sv0, mindist, wall, &
+         uav, vav, wav, uuav, vvav, wwav, uvav, uwav, vwav, svav, thlav, thl2av, sv2av, pres0, &
          svprof, viscratioav, thluav, thlvav, thlwav, svuav, svvav, svwav, presav, &
          uusgsav, vvsgsav, wwsgsav, uwsgsav, thlusgsav, thlwsgsav, svusgsav, svwsgsav, tkesgsav, &
          strain2av, nusgsav
-      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, dtheta, dqt, dsv, startfile, timee, totavtime, runavtime, &
-         iexpnr, ntimee, rk3step, ifinput, nsv, runtime, dt, cexpnr, lreadmean, lreadminl, &
+      use modglobal, only:ib, ie, ih, jb, je, jh, kb, ke, kh, startfile, timee, totavtime,  &
+         ifinput, nsv, dt, cexpnr, lreadmean, lreadminl, &
          totinletav, lreadscal, ltempeq, dzf, numol, prandtlmoli
       use modmpi, only:cmyid, cmyidx, cmyidy, myid
       use modsubgriddata, only:ekm
@@ -2347,7 +2334,7 @@ module modstartup
    subroutine randomnize(field, klev, ampl, ir, ihl, jhl)
 
       use modmpi, only:myid, nprocs
-      use modglobal, only:ib, ie, imax, jmax, jb, je, kb, ke, kh, ierank, BCxm
+      use modglobal, only:ib, ie, imax, jmax, jb, je, kb, ke, kh
       integer(KIND=selected_int_kind(6)):: imm, ia, ic, ir
       integer ihl, jhl
       integer i, j, klev

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -45,11 +45,7 @@ contains
 
 
   subroutine initstat_nc
-    use modglobal, only : kmax,ifnamopt,fname_options,iexpnr
-    use modmpi,    only : mpierr,mpi_logical,comm3d,myid
     implicit none
-
-    integer             :: ierr
 
   end subroutine initstat_nc
 !
@@ -345,7 +341,7 @@ contains
    if (status /= nf90_noerr) call nchandle_error(status)
  end subroutine exitstat_nc
   subroutine writestat_dims_nc(ncid)
-    use modglobal, only : xf,xh,yf,yh,dy,zf,zh,jmax,imax,kb,dxh
+    use modglobal, only : xf,xh,yf,yh,zf,zh,jmax,imax,dxh
     use modmpi, only : myidx, myidy
     implicit none
     integer, intent(in) :: ncid

--- a/src/modstatistics.f90
+++ b/src/modstatistics.f90
@@ -30,7 +30,7 @@ module modstatistics
   save
 
   !NetCDF variables
-  integer :: klow,khigh,i,j,k
+  integer :: i,j,k
 !  real    :: tsamplep,tstatsdumpp,tsample,tstatsdump
 
 contains
@@ -41,11 +41,10 @@ contains
 
   subroutine genstats(tsamplep,tstatsdumpp,umint,vmint,wmint)
 
-  use modfields,        only : um,up,vm,wm,thlm,uav,vav,wav,uuav,vvav,wwav,uvav,vwav,uwav,thlav,thlwav,thlthlav, &
+  use modfields,        only : thlm,uav,vav,wav,uuav,vvav,wwav,uvav,vwav,uwav,thlav,thlwav,thlthlav, &
                                upupav,vpvpav,wpwpav,upvpav,upwpav,vpwpav,thlpwpav
-  use modglobal,        only : ib,ie,ih,jb,je,dy,jh,ke,kb,kh,rk3step,timee,cexpnr,tsample,tstatsdump,&
-                               ltempeq,dxf,dzf,dzhi
-  use modmpi,           only : myid,cmyid,my_real,mpi_sum,mpierr,comm3d
+  use modglobal,        only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,&
+                               ltempeq,dzf,dzhi
   implicit none
 
   real, dimension(ib-ih:ie+ih,jb-jh:je+jh,kb:ke+kh)     :: umint
@@ -148,13 +147,12 @@ contains
  
   subroutine tkestats(tsamplep,tstatsdumpp) ! change of variable names not yet translated across to here ! tg3315 30/11/17
 
-  use modfields,        only : u0,v0,w0,thlm,uyt,vyt,wyt,thlyt,pres0,&
+  use modfields,        only : u0,v0,w0,&
                                tvmx,tvmy,tvmz,strain2av,tsgsmx1,tsgsmx2,tsgsmy1,tsgsmy2,&
-                               tsgsmz1,tsgsmz2,pres0
-  use modglobal,        only : ib,ie,ih,jb,je,jgb,jge,dy,jh,ke,kb,kh,rk3step,cexpnr,tsample,tstatsdump,dzf,zh,dxf,dzf,numol,&
-                               dzfi,dxfi,dyi,dy2i,dxfiq,dxhiq,dyiq,dzfi5,dzh,dzf,dzhi,dzhiq,dxf,dxhi
+                               tsgsmz1,tsgsmz2
+  use modglobal,        only : ib,ie,ih,jb,je,jh,ke,kb,kh,dzf,dxf,dzf,numol,&
+                               dzfi,dxfi,dyi,dy2i,dzf,dzhi,dzhiq,dxf,dxhi
   use modstat_nc,       only : writestat_nc
-  use modsurfdata,      only : thls
   use modsubgriddata,   only : ekm
   implicit none
 
@@ -173,7 +171,7 @@ contains
 !  real :: dummy                            
  
   integer i,j,k,im,ip,jm,jp,km,kp
-  real tstatsdumppi,tsamplep,tstatsdumpp,strain2,tkesgs,nusgs,&
+  real tstatsdumppi,tsamplep,tstatsdumpp,strain2,&
         emom,eomm,eopm,epom,emmo,eomp,epmo,emop,empo,dummy
 
   tekm(:,:,:) = ekm(:,:,:) - numol

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -41,16 +41,11 @@ module modsubgrid
 
 contains
   subroutine initsubgrid
-    use modglobal, only : ih,ib,ie,jh,jb,je,kb,ke,kh,delta,zf,fkar, &
-         pi,ifnamopt,fname_options
-    use modmpi, only : myid
+    use modglobal, only : ih,ib,ie,jh,jb,je,kb,ke,kh,pi
 
     implicit none
 
-    integer   :: i, k
-
     real :: ceps, ch
-    real :: mlen
 
     call subgridnamelist
 
@@ -82,8 +77,8 @@ contains
   end subroutine initsubgrid
 
   subroutine subgridnamelist
-    use modglobal, only : pi,ifnamopt,fname_options,lles
-    use modmpi,    only : myid, nprocs, comm3d, mpierr, my_real, mpi_logical, mpi_integer
+    use modglobal, only : ifnamopt,fname_options,lles
+    use modmpi,    only : myid, comm3d, mpierr, my_real, mpi_logical
 
     implicit none
 
@@ -131,13 +126,11 @@ contains
     ! Diffusion subroutines
     ! Thijs Heus, Chiel van Heerwaarden, 15 June 2007
 
-    use modglobal, only : ih,jh,kh,nsv, lmoist,lles, ib,ie,jb,je,kb,ke,imax,jmax,kmax,&
+    use modglobal, only : ih,jh,kh,nsv, lmoist,&
          ihc,jhc,khc,ltempeq
-    use modfields, only : up,vp,wp,e12p,thl0,thlp,qt0,qtp,sv0,svp,shear
-    use modsurfdata,only : ustar,thlflux,qtflux,svflux
-    use modmpi, only : myid, comm3d, mpierr, my_real,nprocs
+    use modfields, only : up,vp,wp,e12p,thl0,thlp,qt0,qtp,sv0,svp
     implicit none
-    integer n, proces
+    integer n
 
     call closure
     call diffu(up)
@@ -193,21 +186,19 @@ contains
     !                                                                 |
     !-----------------------------------------------------------------|
 
-    use modglobal,   only : ib,ie,jb,je,kb,ke,kh,ih,jh,jmax,delta,ekmin,grav, zf, fkar,jgb,jge,&
-         dx,dxi,dxiq,dx2,dy2,dyi,dyiq,dzf,dzf2,dzfi,dzhi,rk3step,rslabs, &
-         numol,numoli,prandtlmoli,lles, rk3step,dzfiq,lbuoyancy,dzh
-    use modfields,   only : dthvdz,e120,u0,v0,w0,thl0,mindist,wall,shear
-    use modsurfdata, only : dudz,dvdz,thvs,ustar
-    use modmpi,    only : excjs, myid, nprocs, comm3d, mpierr, my_real,mpi_sum,slabsumi
+    use modglobal,   only : ib,ie,jb,je,kb,ke,delta,grav, &
+         dxi,dxiq,dx2,dy2,dyi,dyiq,dzf,dzf2,dzfi,dzhi, &
+         numol,prandtlmoli,dzfiq,lbuoyancy,dzh
+    use modfields,   only : dthvdz,e120,u0,v0,w0,thl0
+    use modsurfdata, only : thvs
+    use modmpi,    only : excjs,slabsumi
     use modboundary, only : closurebc
-    use modinletdata, only : utaui
     implicit none
 
-    real, dimension(ib:ie) :: shearbot
-    real    :: strain2,mlen,uhor,distplus,utaubot,a11,a12,a13, &
-         a21,a22,a23,a31,a32,a33,aa,b11,b12,b13,b21,b22, &
+    real    :: strain2,mlen,a11,a12,a13, &
+         a21,a22,a23,a31,a32,a33,aa,b11,b12,b13,b22, &
          b23,b33,bb,const,const2
-    integer :: i,j,k,kp,km,jp,jm,im,ip,iw,jw,kw,c1,c2
+    integer :: i,j,k,kp,km,jp,jm,im,ip
 
     !  if (lles  .and. rk3step == 1) then        ! compute ekm and ekh only once in complete RK-cycle
     if(lsmagorinsky) then
@@ -478,11 +469,10 @@ contains
     !                                                                 |
     !-----------------------------------------------------------------|
 
-    use modglobal,   only : ib,ie,jb,je,kb,ke,dxi,delta,dy,dyi,dzfi,dzhi,grav,numol,prandtlmol,&
-         dzh, delta
-    use modfields,   only : u0,v0,w0,e120,e12p,dthvdz,thl0,thvf
-    use modsurfdata,  only : dudz,dvdz,thvs
-!    use modmpi,       only : myid
+    use modglobal,   only : ib,ie,jb,je,kb,ke,dxi,delta,dyi,dzfi,dzhi,grav,numol,prandtlmol,&
+         delta
+    use modfields,   only : u0,v0,w0,e120,e12p,dthvdz
+    use modsurfdata,  only : thvs
     implicit none
 
     real    tdef2,prandtlmoli
@@ -582,9 +572,8 @@ contains
 
   subroutine diffc (hi,hj,hk,putin,putout)
 
-    use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,dx2i,dzf,dzfi,dyi,dy2i,&
-         dzhi,dzh2i,jmax, numol, prandtlmoli,lles
-    use modmpi, only : myid
+    use modglobal, only : ib,ie,jb,je,kb,ke,dx2i,dzf,dzfi,dy2i,&
+         dzhi,dzh2i,numol, prandtlmoli,lles
     implicit none
 
     integer, intent(in) :: hi                                                  !<size of halo in i
@@ -671,9 +660,8 @@ contains
   subroutine diffe(putout)
 
     use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,dx2i,dzf,dzfi,&
-         dy2i,dzhi,dzh2i,jmax
+         dy2i,dzh2i
     use modfields, only : e120
-    use modmpi,    only : myid
     implicit none
 
     real, intent(inout) :: putout(ib-ih:ie+ih,jb-jh:je+jh,kb:ke+kh)
@@ -716,17 +704,13 @@ contains
 
   subroutine diffu (putout)
 
-    use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,kmax,dx2i,dxi,lles,&
-         dzf,dzfi,dy,dyi,dy2i,dzhi,dzhiq,jmax,numol
+    use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,dx2i,dxi,lles,&
+         dzf,dzfi,dyi,dzhi,dzhiq,numol
     use modfields, only : u0,v0,w0
-    use modsurfdata,only : ustar
-    use modmpi, only    : myid
     implicit none
 
     real, intent(inout) :: putout(ib-ih:ie+ih,jb-jh:je+jh,kb:ke+kh)
     real                :: emmo,emom,emop,empo
-    real                :: fu,dummy
-    real                :: ucu, upcu
     integer             :: i,j,k,jm,jp,km,kp
 
     if (lles) then
@@ -827,16 +811,13 @@ contains
   subroutine diffv (putout)
 
     use modglobal, only   : ib,ie,ih,jb,je,jh,kb,ke,kh,dxi,dzf,dzfi,dyi,&
-         dy2i,dzhi,dzhiq,jmax,numol,lles
+         dy2i,dzhi,dzhiq,numol,lles
     use modfields, only   : u0,v0,w0
-    use modsurfdata,only  : ustar
-    use modmpi, only      : myid
 
     implicit none
 
     real, intent(inout) :: putout(ib-ih:ie+ih,jb-jh:je+jh,kb:ke+kh)
     real                :: emmo, eomm,eomp,epmo
-    real                :: fv, vcv,vpcv
     integer             :: i,j,k,jm,jp,km,kp
 
     if (lles) then
@@ -941,10 +922,9 @@ contains
 
   subroutine diffw(putout)
 
-    use modglobal, only   : ib,ie,ih,jb,je,jh,kb,ke,kh,kmax,dxi,dy,&
-         dyi,dy2i,dzf,dzfi,dzhi,dzhiq,jmax,numol,lles
+    use modglobal, only   : ib,ie,ih,jb,je,jh,kb,ke,kh,dxi,&
+         dyi,dzf,dzfi,dzhi,dzhiq,numol,lles
     use modfields, only   : u0,v0,w0
-    use modmpi, only      : myid
     implicit none
 
     !*****************************************************************

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -75,9 +75,8 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine inittimedep
     use modmpi,    only :myid,my_real,mpi_logical,mpierr,comm3d
-    use modglobal, only :cexpnr,kb,ke,kh,kmax,ifinput,runtime,zf,skyLW,nfcts
+    use modglobal, only :kb,ke,kh,kmax,cexpnr,ifinput,skyLW,nfcts
     use modibmdata, only : bctfxm, bctfxp, bctfym, bctfyp, bctfz!, bctfzf
-    use modfields, only: thlprof
     !use initfac, only : netsw !Should probably be moved to somewhere else
 
     implicit none
@@ -85,7 +84,6 @@ contains
     character (80):: chmess
     character (1) :: chmess1
     integer :: k,t,n,ierr
-    real :: dummyr
     real, allocatable, dimension (:) :: height
 
     ltimedep = (ltimedepsurf .or. ltimedepnudge) .or. (ltimedeplw .or. ltimedepsw)
@@ -319,7 +317,6 @@ contains
   end subroutine timedep
 
   subroutine timedepsurf
-    use modmpi,     only : myid
     use modglobal,  only : timee
     use modibmdata, only : bctfxm, bctfxp, bctfym, bctfyp, bctfz!, bctfzf
     implicit none
@@ -358,11 +355,10 @@ contains
 
   subroutine timedepnudge
     use modfields,   only : thlprof, qtprof, uprof, vprof
-    use modglobal,   only : timee,dzf,dzh,kb,ke,kh,kmax
-    use modmpi,      only : myid
+    use modglobal,   only : timee
 
     implicit none
-    integer t,k
+    integer t
     real fac
 
     if(.not.(ltimedepnudge)) return
@@ -397,10 +393,9 @@ contains
 
   subroutine timedeplw
     use modglobal,    only : timee, skyLW, rk3step, tnextEB
-    use modmpi,       only : myid
 
     implicit none
-    integer t,k
+    integer t
     real fac
 
     if(.not.(ltimedeplw)) return

--- a/src/modtrees.f90
+++ b/src/modtrees.f90
@@ -10,15 +10,14 @@ save
 
 contains
     subroutine createtrees
-    use modglobal,  only : ltrees,ntrees,tree,cexpnr,ifinput,zh,zf,dzh,dzfi,dzhi,dzf,Qstar,&
-                           dec,lad,kb,ke,cp,rhoa,ntree_max,dQdt,tr_A,dy,xh
-    use modfields,  only : um,vm,wm,thlm,qt0,svp,up,vp,wp,thlp,qtp,Rn,clai,qc,qa,ladzh,ladzf
+    use modglobal,  only : ltrees,ntrees,tree,cexpnr,ifinput,dzf,Qstar,&
+                           dec,lad,ke,cp,rhoa,ntree_max,dQdt,tr_A,dy,xh
+    use modfields,  only : Rn,clai,qc,qa,ladzh,ladzf
     use modmpi,     only : myid,comm3d,mpierr,MY_REAL
     use modsurfdata,only : wtsurf
     use modibmdata ,only : bctfz
     implicit none
     integer :: n,k
-    real :: Rq
     character(80) chmess
 
     if ((ltrees .eqv. .false.) .or. (ntrees==0)) return
@@ -165,17 +164,16 @@ contains
     end subroutine createtrees
 
     subroutine trees
-    use modglobal,  only : ib,ie,jb,je,kb,ke,ih,jh,dzf,xh,dxf,numol,prandtlmol,rlv,cp,tree,&
-                           ntrees,ltrees,itot,jtot,cd,ud,lmoist,nsv,dxf,dy,dzf,dzfi,zf,dy,zh,&
-                           ltempeq,pref0,r_s,lad,rhoa,ntree_max,lsize,Qstar,dQdt,BCxs,tr_A,&
+    use modglobal,  only : ib,ie,jb,je,kb,ke,dzf,xh,dxf,numol,rlv,cp,tree,&
+                           ntrees,ltrees,itot,jtot,cd,ud,lmoist,nsv,dxf,dy,dzf,dzfi,dy,zh,&
+                           ltempeq,pref0,r_s,rhoa,ntree_max,lsize,Qstar,dQdt,BCxs,tr_A,&
                            rslabs,kmax,rv,rd
-    use modfields,  only : um,vm,wm,thlm,qtm,svp,up,vp,wp,thlp,qtp,svm,Rn,qc,qa,thlm,clai,&
+    use modfields,  only : um,vm,wm,thlm,qtm,svp,up,vp,wp,thlp,qtp,svm,Rn,qa,thlm,&
                            ladzf,ladzh,IIcs,tr_omega,&
                            tr_u,tr_v,tr_w,tr_qt,tr_qtR,tr_qtA,tr_thl,tr_sv,thlpcar
     use modmpi,     only : myidx,myidy,mpi_sum,mpierr,comm3d,mpierr,my_real,nprocx,nprocy
-    use modsurfdata,only : wtsurf,wttop,wqtop
+    use modsurfdata,only : wttop,wqtop
     use modibmdata, only : bctfz
-    use modsubgriddata, only : ekh
     implicit none
     integer :: i,j,k,n,m,il,iu,jl,ju,kl,ku
     real :: e_sat,e_vap,qh,qe,shade,r_a,s,D,numoli,gam,Rq,qhmin,qhmax,omega

--- a/src/program.f90
+++ b/src/program.f90
@@ -24,7 +24,7 @@ program DALESURBAN      !Version 48
 !!----------------------------------------------------------------
 !!     0.0    USE STATEMENTS FOR CORE MODULES
 !!----------------------------------------------------------------
-  use modmpi,            only : initmpi,exitmpi,myid,starttimer
+  use modmpi,            only : initmpi,exitmpi,starttimer
   use modglobal,         only : initglobal,rk3step,timeleft
   use modstartup,        only : readnamelists,init2decomp,checkinitvalues,readinitfiles,exitmodules
   use modfields,         only : initfields

--- a/src/scalsource.f90
+++ b/src/scalsource.f90
@@ -276,7 +276,7 @@
 
 subroutine createscals
 
-  use modglobal,  only : nsv,cexpnr,ifinput,lscasrc,nscasrc,scasrcp,lscasrcl,nscasrcl,scasrcl,lscasrcr
+  use modglobal,  only : nsv,cexpnr,ifinput,lscasrc,nscasrc,scasrcp,lscasrcl,nscasrcl,scasrcl
   use modmpi,     only : myid,MY_REAL,comm3d,mpierr
   implicit none
   integer :: n,m
@@ -378,17 +378,15 @@ end subroutine
 
 subroutine scalsource
 
-  use modglobal,  only : pi,nsv,ib,ie,jb,je,kb,ke,ih,jh,kh,ihc,jhc,khc,xf,zf,xh,zh,dx,dy,imax,itot,jmax,jtot,lchem,&
-                         xS,yS,zS,xSb,ySb,zSb,xSe,ySe,zSe,SS,sigS,lscasrc,lscasrcl,lscasrcr,libm,dxfi,dzfi,nscasrc,scasrcp,nscasrcl,scasrcl
-  use modfields,  only : svp,svpp
-  use modmpi,     only : myid,myidx,myidy,mpierr,MY_REAL,comm3d,MPI_SUM
+  use modglobal,  only : pi,nsv,ib,ie,jb,je,kb,ke,zf,dx,dy,imax,jmax,&
+                         xS,yS,zS,xSb,ySb,zSb,xSe,ySe,zSe,SS,sigS,lscasrc,lscasrcl,dzfi,nscasrc,scasrcp,nscasrcl,scasrcl
+  use modfields,  only : svp
+  use modmpi,     only : myidx,myidy
 
   implicit none
   integer :: i,j,k,n,ns
   real :: dxi, dyi
   real :: ra2 = 0.
-  real :: scalsum = 0.
-  real :: scalsumt = 0.
   real :: px = 0., py = 0., pz = 0.0, vx = 0., vy = 0., vz = 0., lsx = 0., lsy = 0., lsz = 0., dot_projection = 0.
 
   dxi = 1./dx

--- a/src/tstep.f90
+++ b/src/tstep.f90
@@ -43,15 +43,15 @@
 subroutine tstep_update
 
 
-  use modglobal, only : ib,ie,jb,je,rk3step,timee,runtime,dtmax,dt,ntimee,ntrun,courant,diffnr,&
-                        kb,ke,dx,dxi,dx2i,dyi,dy2i,dzh,dt_lim,ladaptive,timeleft,dt,lwarmstart,&
+  use modglobal, only : ib,ie,jb,je,rk3step,timee,dtmax,dt,ntimee,ntrun,courant,diffnr,&
+                        kb,ke,dxi,dx2i,dyi,dy2i,dzh,dt_lim,ladaptive,timeleft,dt,lwarmstart,&
                         dzh2i
   use modfields, only : um,vm,wm
   use modsubgriddata, only : ekm,ekh
-  use modmpi,    only : myid,comm3d,mpierr,mpi_max,my_real
+  use modmpi,    only : comm3d,mpierr,mpi_max,my_real
   implicit none
 
-  integer       :: i, j, k,imin,kmin
+  integer       :: i, j, k
   real,save     :: courtot=-1.,diffnrtot=-1.
   real          :: courtotl,courold,diffnrtotl,diffnrold
 !  logical,save  :: spinup=.true.
@@ -165,27 +165,24 @@ end subroutine tstep_update
 subroutine tstep_integrate
 
 
-  use modglobal, only : ib,ie,jb,jgb,je,kb,ke,nsv,dt,rk3step,e12min,lmoist,timee,ntrun,&
-                        linoutflow, iinletgen,ltempeq,idriver,BCtopm,BCtopm_pressure,BCxm_periodic,BCym_periodic, &
-                        dzf,dzhi,dzf,dxf,ifixuinf,thlsrc,lchem,ibrank,ierank,jerank,jbrank,BCxm,BCym,ihc,jhc,khc,dyi,dxfi,BCxT,BCxq,BCxs,BCyT,BCyq,BCys
-  use modmpi, only    : cmyid,myid,nprocs
+  use modglobal, only : ib,ie,jb,je,kb,ke,nsv,dt,rk3step,e12min,lmoist,timee,&
+                        iinletgen,ltempeq,idriver,BCtopm,BCtopm_pressure,BCxm_periodic,BCym_periodic, &
+                        ifixuinf,thlsrc,lchem,ierank,jerank,BCxm,BCym
+  use modmpi, only    : cmyid,myid
   use modfields, only : u0,um,up,v0,vm,vp,w0,wm,wp,&
-                        thl0,thlm,thlp,qt0,qtm,qtp,e120,e12m,e12p,sv0,svm,svp,uouttot,&
-                        wouttot,dpdxl,dgdt,momfluxb,tfluxb,qfluxb,thl0c
-  use modinletdata, only: totalu,di_test,dr,thetar,thetai,displ,irecy, &
-                          dti_test,dtr,thetati,thetatr,q0,lmoi,lmor,utaui,utaur,&
-                          storetdriver, nstepread, nstepreaddriver, irecydriver
-  use modsubgriddata, only : loneeqn,ekm,ekh
+                        thl0,thlm,thlp,qt0,qtm,qtp,e120,e12m,e12p,sv0,svm,svp,&
+                        dpdxl,dgdt,thl0c
+  use modinletdata, only: nstepreaddriver, irecydriver
+  use modsubgriddata, only : loneeqn
   use modchem, only : chem
   use decomp_2d, only : exchange_halo_z
-  use modpois, only : pij, dpdztop
 
   implicit none
 
-  integer i,j,k,n,m
+  integer i,j,k,n
   real rk3coef,rk3coefi
 
-  rk3coef = dt / (4. - dble(rk3step))
+  rk3coef = dt / (4. - real(rk3step))
   rk3coefi = 1./rk3coef
 
   if(ifixuinf==2) then

--- a/src/wf_gr.f90
+++ b/src/wf_gr.f90
@@ -17,20 +17,16 @@
 !
 SUBROUTINE wfGR(hi,hj,hk,ioq,ioqflux,icth,obcqfluxA,qcell,qwall,hurel,resc,ress,n,ind,wforient)
    !wfGR
-   USE modglobal, ONLY : dzf,dzfi,dzh2i,dzhi,dzhiq,dy,dyi,dy2i,dyi5,dxf,dxh,dxfi,dxhi,dxh2i,ib,ie,jb,je,kb,ke,fkar,grav,jmax,rk3step
+   USE modglobal, ONLY : dzf,dzfi,dzh2i,dyi,dy2i,dxf,dxh,dxfi,dxh2i,ib,ie,jb,je,kb,ke,fkar,jmax
    USE modsubgriddata, ONLY:ekh
    USE modmpi, ONLY:myid
    USE initfac, ONLY:block
    USE modibmdata
-   INTEGER i, j, k, jl, ju, kl, ku, il, iu, km, im, jm, ip, jp, kp
+   INTEGER i, j, k, jl, ju, kl, ku, il, iu, km, im, jm, ip, jp
 
    REAL :: bcqflux = 0. !temp storage for temperature flux
-   REAL :: bcmomflux = 0. !temp storage for momentum flux
-   REAL :: dummy = 0. !for debugging
    REAL :: delta = 0. !distance from wall
    REAL :: fkar2 !fkar^2, von Karman constant squared
-   REAL :: emmo = 0., epmo = 0., epom = 0., emom = 0., eopm = 0., eomm = 0., empo = 0.
-   REAL :: umin = 0.0001 !m^2/s^2
    REAL :: cveg=0.8 !hardcoded for now, !fraction of GR covered in vegetation, should be made into a proper model parameter (-> modglobal)
 
    INTEGER, INTENT(in) :: hi !<size of halo in i

--- a/src/wfmneutral.f90
+++ b/src/wfmneutral.f90
@@ -15,18 +15,16 @@
 !
 !  Copyright 2006-2021 the uDALES Team.
 !
-SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wforient)
+SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,wforient)
    !wfmneutral
    !wf for momentum under neutral conditions
    !calculating wall function for momentum assuming neutral conditions
    !follow approach in wfuno
    !fluxes in m2/s2
-   USE modglobal, ONLY : dzf,dzfi,dzh2i,dzhi,dzhiq,dy,dyi,dy2i,dyi5,dxf,dxh,dxfi,dxhi,dxh2i,ib,ie,jb,je,kb,ke,fkar,jmax,rk3step,kmax,jge,jgb
-   USE modsubgriddata, ONLY:ekh, ekm
-   USE modmpi, ONLY:myid
-   USE initfac, ONLY:block
+   USE modglobal, ONLY : dzf,dzfi,dzhi,dzhiq,dxf,dxhi,ib,ie,jb,je,kb,ke,fkar
+   USE modsubgriddata, ONLY:ekm
    USE modibmdata
-   INTEGER i, j, k, jl, ju, kl, ku, il, iu, km, im, jm, ip, jp, kp
+   INTEGER i, j, k, jl, ju, il, iu, km
 
    REAL :: bcmomflux = 0. !temp storage for momentum flux
    REAL :: ctm = 0. !momentum transfer coefficient
@@ -36,7 +34,7 @@ SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wfor
    REAL :: utang1Int !Interpolated 1st tangential velocity component needed for stability calculation (to T location)
    REAL :: utang2Int !Interpolated 2nd tangential velocity component needed for stability calculation (to T location)
    REAL :: fkar2 !fkar^2, von Karman constant squared
-   REAL :: emmo = 0., epmo = 0., epom = 0., emom = 0., eopm = 0., eomm = 0., empo = 0.
+   REAL :: emom = 0., eomm = 0.
    REAL :: umin = 0.0001 !m^2/s^2
 
    INTEGER, INTENT(in) :: hi !<size of halo in i
@@ -48,8 +46,6 @@ SUBROUTINE wfmneutral(hi,hj,hk,iout1,iout2,iomomflux,utang1,utang2,z0,n,ind,wfor
    REAL, INTENT(in)    :: z0
    REAL, INTENT(in)    :: utang1(ib - hi:ie + hi, jb - hj:je + hj, kb - hk:ke + hk) !tangential velocity field
    REAL, INTENT(in)    :: utang2(ib - hi:ie + hi, jb - hj:je + hj, kb - hk:ke + hk) !second tangential velocity field
-   INTEGER, INTENT(in) :: n ! number of the block, used to get i,j,k-indeces
-   INTEGER, INTENT(in) :: ind ! in case of y-wall (case 3x & 4x) "ind" is used for j-index, otherwise this is irrelevant
    INTEGER, INTENT(in) :: wforient !orientation of the facet see below:
    !frist digit, orientation of wall, determines iteration indices
    !second digit, if for momentum or for scalar (necessary because of staggered grid -> which variable to interpolate)


### PR DESCRIPTION
Sorry for the delay in getting this to you guys. I had some competing projects but didn't want this to get lost on my harddrive.

This PR addresses the vast majority of gfortran compiler warnings. These were mostly unused variables. I strongly recommend that you take a look at the remaining warnings and resolve them and then make it a requirement (at least in CI) to compile with with the `-Werror` flag to prevent errors from accreting again.