### PR TITLE
Fix temperature drift caused by ekh timing mismatch in flux-type top BC

### DIFF
--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -27,7 +27,8 @@ module modboundary
    save
    private
    public :: initboundary, boundary, grwdamp, ksp, tqaver, halos, bcp, bcpup, closurebc, &
-             xm_periodic, xT_periodic, xq_periodic, xs_periodic, ym_periodic, yT_periodic, yq_periodic, ys_periodic
+             xm_periodic, xT_periodic, xq_periodic, xs_periodic, ym_periodic, yT_periodic, yq_periodic, ys_periodic, &
+             fluxtop
    integer :: ksp = -1 !<    lowest level of sponge layer
    real, allocatable :: tsc(:) !<   damping coefficients to be used in grwdamp.
    real :: rnu0 = 2.75e-3

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -135,14 +135,17 @@ contains
     ! Thijs Heus, Chiel van Heerwaarden, 15 June 2007
 
     use modglobal, only : ih,jh,kh,nsv, lmoist,lles, ib,ie,jb,je,kb,ke,imax,jmax,kmax,&
-         ihc,jhc,khc,ltempeq
+         ihc,jhc,khc,ltempeq, BCtopT, BCtopT_flux
     use modfields, only : up,vp,wp,e12p,thl0,thlp,qt0,qtp,sv0,svp,shear
-    use modsurfdata,only : ustar,thlflux,qtflux,svflux
+    use modsurfdata,only : ustar,thlflux,qtflux,svflux, wttop
+    use modboundary, only : fluxtop
     use modmpi, only : myid, comm3d, mpierr, my_real,nprocs
     implicit none
     integer n, proces
 
     call closure
+    if (ltempeq .and. BCtopT == BCtopT_flux) &
+        call fluxtop(thl0, ekh, wttop)
     call diffu(up)
     call diffv(vp)
     call diffw(wp)


### PR DESCRIPTION
closure() updates ekh to ekh_{N+1} at the start of each RK3 substep, but fluxtop() (called via boundary()) had already set the top ghost cell thl0(ke+1) using the previous ekh_N. diffc() then computed the top-boundary flux using the mismatched ekh_{N+1}, causing the realized flux to deviate from the prescribed wttop by ~0.72%, producing a systematic linear domain-temperature drift (dT/dt not converging to zero, scaling with dt).

Fix: call fluxtop() again immediately after closure() inside subgrid(), using the just-updated ekh, before diffc() consumes the ghost cell. Only active when ltempeq .and. BCtopT == BCtopT_flux.

Verified on hpc: drift reduced from +7.93e-04 K.m/s to -2.10e-05 K.m/s (97% reduction), case 001 (unpatched) vs case 002 (patched), bctfz = wttop = -0.1. Re-verified with a clean rebuild (case 005, 26000s run) to confirm the cleaned-up patch reproduces identical convergence behavior. 
Closes #317