### PR TITLE
Reassure fluxtop boundary condition after ekm and ekh comutation at current iteration

### DIFF
--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -390,6 +390,48 @@ contains
    end subroutine boundary
 
 
+   subroutine reassure_fluxtop_boundary
+    use modglobal,      only : ltempeq, lmoist, nsv, &
+                               BCtopm, BCtopT, BCtopq, BCtops, &
+                               BCtopm_freeslip, BCtopm_pressure, &
+                               BCtopT_flux, BCtopq_flux, BCtops_flux
+    use modfields,      only : u0, v0, um, vm, thl0, thlm, qt0, qtm
+    use modsubgriddata, only : ekh, ekm
+    use modsurfdata,    only : wttop, wqtop, wsvtop
+    implicit none
+
+    select case(BCtopm)
+      case(BCtopm_freeslip)
+        !free-slip = zero-flux
+        call fluxtop(um, ekm, 0.0)
+        call fluxtop(u0, ekm, 0.0)
+        call fluxtop(vm, ekm, 0.0)
+        call fluxtop(v0, ekm, 0.0)
+      case(BCtopm_pressure)
+        call fluxtop(um, ekm, 0.0)
+        call fluxtop(u0, ekm, 0.0)
+        call fluxtop(vm, ekm, 0.0)
+        call fluxtop(v0, ekm, 0.0)
+      case default
+    end select
+
+    if (ltempeq .and. (BCtopT .eq. BCtopT_flux)) then
+      call fluxtop(thlm, ekh, wttop)
+      call fluxtop(thl0, ekh, wttop)
+    end if
+
+    if (lmoist .and. (BCtopq .eq. BCtopq_flux)) then
+      call fluxtop(qtm, ekh, wqtop)
+      call fluxtop(qt0, ekh, wqtop)
+    end if
+
+    if (nsv > 0 .and. (BCtops .eq. BCtops_flux)) then
+      call fluxtopscal(wsvtop)
+      call fluxtopscal(wsvtop)
+    end if
+   end subroutine reassure_fluxtop_boundary
+
+
    subroutine closurebc
      use modsubgriddata, only : ekm, ekh
      use modglobal,      only : ib, ie, jb, je, kb, ke, ih, jh, kh, numol, prandtlmoli, &
@@ -458,6 +500,8 @@ contains
          ekh(:, je + 1, :) = ekh(:, jb, :)
        end if
      end if
+
+     call reassure_fluxtop_boundary
 
    end subroutine closurebc
 

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -27,8 +27,7 @@ module modboundary
    save
    private
    public :: initboundary, boundary, grwdamp, ksp, tqaver, halos, bcp, bcpup, closurebc, &
-             xm_periodic, xT_periodic, xq_periodic, xs_periodic, ym_periodic, yT_periodic, yq_periodic, ys_periodic, &
-             fluxtop
+             xm_periodic, xT_periodic, xq_periodic, xs_periodic, ym_periodic, yT_periodic, yq_periodic, ys_periodic
    integer :: ksp = -1 !<    lowest level of sponge layer
    real, allocatable :: tsc(:) !<   damping coefficients to be used in grwdamp.
    real :: rnu0 = 2.75e-3

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -135,17 +135,14 @@ contains
     ! Thijs Heus, Chiel van Heerwaarden, 15 June 2007
 
     use modglobal, only : ih,jh,kh,nsv, lmoist,lles, ib,ie,jb,je,kb,ke,imax,jmax,kmax,&
-         ihc,jhc,khc,ltempeq, BCtopT, BCtopT_flux
+         ihc,jhc,khc,ltempeq
     use modfields, only : up,vp,wp,e12p,thl0,thlp,qt0,qtp,sv0,svp,shear
-    use modsurfdata,only : ustar,thlflux,qtflux,svflux, wttop
-    use modboundary, only : fluxtop
+    use modsurfdata,only : ustar,thlflux,qtflux,svflux
     use modmpi, only : myid, comm3d, mpierr, my_real,nprocs
     implicit none
     integer n, proces
 
     call closure
-    if (ltempeq .and. BCtopT == BCtopT_flux) &
-        call fluxtop(thl0, ekh, wttop)
     call diffu(up)
     call diffv(vp)
     call diffw(wp)


### PR DESCRIPTION
Refactoring the modification made in commit …
https://github.com/uDALES/u-dales/commit/67d149b54a483524ed8ed913c7cac05357fbc67c

Extending the commit to ensure fluxtop bc also for momentum and other scalars, along with temperature after ekm and ekh comutation at every iteration step.