### PR TITLE
Fix GNU compiler warnings: unused symbols, DOUBLE PRECISION promotion, filename truncation (closes #333)

### DIFF
--- a/.github/scripts/summarise_warnings.sh
+++ b/.github/scripts/summarise_warnings.sh
@@ -22,6 +22,9 @@ label="${2:-build}"
 out="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
 if [ ! -f "$log" ]; then
+    # Loud on stdout: a missing log means this reported nothing, and a silent
+    # exit 0 would be indistinguishable from a clean build.
+    echo "WARNING: no build log at '${log}' -- no warnings were summarised." >&2
     echo "### Compiler warnings — ${label}" >> "$out"
     echo >> "$out"
     echo "_No build log at \`${log}\` — nothing to report._" >> "$out"
@@ -35,6 +38,10 @@ counts="$(grep -ohE '\[-W[a-z-]+\]' "$log" | tr -d '[]' | sort | uniq -c | sort 
 
 total=$(printf '%s' "$counts" | awk '{s+=$1} END {print s+0}')
 actionable=$(printf '%s' "$counts" | awk -v re="$BENIGN_RE" '$2 !~ re {s+=$1} END {print s+0}')
+
+# Echoed to the job log as well as the summary, so the log alone shows whether
+# this actually ran against a real build.
+echo "${label}: ${total} warning(s), ${actionable} actionable, from '${log}'"
 
 {
     echo "### Compiler warnings — ${label}"

--- a/.github/scripts/summarise_warnings.sh
+++ b/.github/scripts/summarise_warnings.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Summarise compiler warnings from a build log into the GitHub step summary.
+#
+# Reporting only: this never fails the build, by design. CI does not pin its
+# compilers (`apt install gfortran`, `brew install gcc` on rolling runner
+# images), so each runner legitimately reports a different set of warnings, and
+# a newer image can introduce new ones with no change to this repository.
+# Gating on that would turn CI red on an unrelated PR. Surfacing the counts
+# keeps the signal without the brittleness.
+#
+# Classes listed in BENIGN below were reviewed in #334 and are correct as they
+# stand; everything else is flagged for review. If a class here starts hiding
+# real problems, drop it from the list rather than muting the report.
+#
+# Usage: summarise_warnings.sh <build.log> <label>
+
+set -uo pipefail
+
+log="${1:?usage: summarise_warnings.sh <build.log> <label>}"
+label="${2:-build}"
+out="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+if [ ! -f "$log" ]; then
+    echo "### Compiler warnings — ${label}" >> "$out"
+    echo >> "$out"
+    echo "_No build log at \`${log}\` — nothing to report._" >> "$out"
+    exit 0
+fi
+
+# gfortran/clang warning classes are reported as a trailing [-Wname] tag.
+BENIGN_RE='^-W(compare-reals|unused-value)$'
+
+counts="$(grep -ohE '\[-W[a-z-]+\]' "$log" | tr -d '[]' | sort | uniq -c | sort -rn || true)"
+
+total=$(printf '%s' "$counts" | awk '{s+=$1} END {print s+0}')
+actionable=$(printf '%s' "$counts" | awk -v re="$BENIGN_RE" '$2 !~ re {s+=$1} END {print s+0}')
+
+{
+    echo "### Compiler warnings — ${label}"
+    echo
+    if [ "$total" -eq 0 ]; then
+        echo "None."
+        exit 0
+    fi
+    if [ "$actionable" -eq 0 ]; then
+        echo "**0 actionable** (${total} known-benign)."
+    else
+        echo "**${actionable} actionable** of ${total} — see below."
+    fi
+    echo
+    echo "| count | class | |"
+    echo "|---|---|---|"
+    printf '%s\n' "$counts" | while read -r n c; do
+        [ -n "${n:-}" ] || continue
+        if printf '%s' "$c" | grep -qE "$BENIGN_RE"; then
+            tag="known-benign (#334)"
+        else
+            tag="**review**"
+        fi
+        echo "| ${n} | \`${c}\` | ${tag} |"
+    done
+} >> "$out"
+
+[ "$actionable" -eq 0 ] && exit 0
+
+# Pair each warning with the file:line: header that precedes it, so the report
+# points at source rather than just counting.
+{
+    echo
+    echo "<details><summary>Actionable warning sites</summary>"
+    echo
+    echo '```'
+    # Two shapes to handle:
+    #   gfortran: a "file:line:col:" header line, then "Warning: msg [-Wflag]"
+    #   clang:    "file:line:col: warning: msg [-Wflag]" all on one line
+    awk -v re="$BENIGN_RE" '
+        function emit(loc, msg, flag,   p, n) {
+            if (flag ~ re) return
+            sub(/:[0-9]+:?$/, "", loc)          # drop the column, keep file:line
+            n = split(loc, p, "/")
+            printf "%s: %s [%s]\n", p[n], msg, flag
+        }
+        # clang single-line form
+        /:[0-9]+:[0-9]+: *warning:/ && /\[-W[a-z-]+\]/ {
+            match($0, /\[-W[a-z-]+\]/)
+            flag = substr($0, RSTART+1, RLENGTH-2)
+            loc = $0; sub(/: *warning:.*/, "", loc)
+            msg = $0; sub(/.*warning: /, "", msg); sub(/ \[-W.*/, "", msg)
+            emit(loc, msg, flag)
+            next
+        }
+        # gfortran location header
+        /^[^ ].*:[0-9]+:[0-9]+:[[:space:]]*$/ { loc = $0; next }
+        # gfortran message, refers back to the last header
+        /^[[:space:]]*Warning:/ && /\[-W[a-z-]+\]/ {
+            match($0, /\[-W[a-z-]+\]/)
+            flag = substr($0, RSTART+1, RLENGTH-2)
+            msg = $0; sub(/.*Warning: /, "", msg); sub(/ \[-W.*/, "", msg)
+            if (loc != "") emit(loc, msg, flag)
+        }
+    ' "$log" | sort -u -t: -k1,1 -k2,2n | head -50
+    echo '```'
+    echo "</details>"
+} >> "$out"
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,13 @@ jobs:
     - name: Build current branch for integration tests
       shell: bash -l {0}
       run: |
+        # This step overrides the default shell, which drops GitHub's `-eo
+        # pipefail`. The build is piped into tee below, so pipefail is required
+        # or a failed build would be masked by tee's exit status.
+        set -o pipefail
         build_dir="build/${{ matrix.build-type }}"
         build_dir="$(printf '%s' "$build_dir" | tr '[:upper:]' '[:lower:]')"
+        echo "UDALES_BUILD_LOG=${build_dir}/build.log" >> "$GITHUB_ENV"
         source .github/scripts/setup_mpi_env.sh "${{ matrix.os }}"
         if [ ${{ matrix.os }} = 'macos-latest' ]; then
           which gfortran
@@ -79,7 +84,13 @@ jobs:
           -DMPI_Fortran_COMPILER="$UDALES_MPI_FORTRAN_COMPILER" \
           -DMPI_C_COMPILER="$UDALES_MPI_C_COMPILER" \
           -DMPIEXEC_EXECUTABLE="$UDALES_MPIEXEC"
-        cmake --build "$build_dir" -- -j 4
+        cmake --build "$build_dir" -- -j 4 2>&1 | tee "$build_dir/build.log"
+
+    - name: Summarise compiler warnings
+      # Reporting only -- deliberately never fails the build. See the script
+      # header for why this is not a -Werror gate.
+      if: always()
+      run: bash .github/scripts/summarise_warnings.sh "$UDALES_BUILD_LOG" "${{ matrix.os }} ${{ matrix.build-type }}"
 
     - name: Build and test uDALES
       shell: bash -l {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,11 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -std=f2008" CACHE STRING "Fortran flags" FORCE)
+    # -fdefault-double-8 is required alongside -fdefault-real-8: on its own,
+    # -fdefault-real-8 also widens DOUBLE PRECISION to 16 bytes, which made every
+    # `dble(...)` and `1d0` literal software-emulated quad precision that was then
+    # truncated straight back to real(8) on assignment.
+    set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fdefault-double-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -std=f2008" CACHE STRING "Fortran flags" FORCE)
     set(CMAKE_Fortran_FLAGS_DEBUG "-g -fbacktrace -O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion" CACHE STRING "Fortran debug flags" FORCE)
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3" CACHE STRING "Fortran release flags" FORCE)
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")

--- a/src/initfac.f90
+++ b/src/initfac.f90
@@ -56,8 +56,10 @@
       real, allocatable    :: netsw(:) !net shortwave radiation on facets
       real, allocatable    :: facLWin(:) !incoming longwave on facets [W/m2]
       real, allocatable    :: vfsparse(:)
-      real, allocatable    :: ivfsparse(:)
-      real, allocatable    :: jvfsparse(:)
+      ! facet indices of the sparse view-factor entries: integer, matching the
+      ! `%d %d %.6f` layout written by the pre-processing.
+      integer, allocatable :: ivfsparse(:)
+      integer, allocatable :: jvfsparse(:)
       !temperature
       real, allocatable    :: Tfacinit(:) !initial facet temperatures
       real, allocatable    :: Tfacinit_layers(:,:) !initial facet temperatures

--- a/src/modEB.f90
+++ b/src/modEB.f90
@@ -377,7 +377,7 @@ contains
     ! bare soil
     ! E = max(0,(1-vegetation%) * rhoa * (qa-qsat(TGR)*hu) * (1/(rs+ra))
 
-    use modglobal, only:nfcts, rlv, rlvi, rhoa, cp, wfc, wwilt, rsmin, GRLAI, tEB, rsmax, lconstW
+    use modglobal, only:nfcts, rlv, rlvi, rhoa, wfc, wwilt, rsmin, GRLAI, tEB, rsmax, lconstW
     use initfac, only:netSW, fachurel, faclGR, facwsoil, facf, facT, facefi, facqsat, facd, faca, qsat
 
     integer :: n

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -911,7 +911,7 @@ contains
      use modsubgriddata, only : loneeqn
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      v0(ie + 1, :, :) = v0(ie+1, :, :) - (v0(ie+1, :, :) - v0(ie, :, :))*dxi*rk3coef*uouttot
      w0(ie + 1, :, :) = w0(ie+1, :, :) - (w0(ie+1, :, :) - w0(ie, :, :))*dxi*rk3coef*uouttot
@@ -926,30 +926,12 @@ contains
    end subroutine xmo_convective
 
 
-   subroutine xmo_Neumann
-     use modglobal,      only : ie
-     use modfields,      only : v0, vm, w0, wm, e120, e12m
-     use modsubgriddata, only : loneeqn
-
-     v0(ie + 1, :, :) = v0(ie, :, :)
-     w0(ie + 1, :, :) = w0(ie, :, :)
-     vm(ie + 1, :, :) = vm(ie, :, :)
-     wm(ie + 1, :, :) = wm(ie, :, :)
-
-     if (loneeqn) then
-       e120(ie + 1, :, :) = e120(ie, :, :)
-       e12m(ie + 1, :, :) = e12m(ie, :, :)
-     end if
-
-   end subroutine xmo_Neumann
-
-
    subroutine xTo_convective
      use modglobal, only : ie, dxi, rk3step, dt
      use modfields, only : thl0, thlm, uouttot
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      thl0(ie + 1, :, :) = thl0(ie+1, :, :) - (thl0(ie + 1, :, :) - thl0(ie, :, :))*dxi*rk3coef*uouttot
      thlm(ie + 1, :, :) = thlm(ie+1, :, :) - (thlm(ie + 1, :, :) - thlm(ie, :, :))*dxi*rk3coef*uouttot
@@ -957,22 +939,12 @@ contains
    end subroutine xTo_convective
 
 
-   subroutine xTo_Neumann
-     use modglobal, only : ie
-     use modfields, only : thl0, thlm
-
-     thl0(ie + 1, :, :) = thl0(ie, :, :)
-     thlm(ie + 1, :, :) = thlm(ie, :, :)
-
-   end subroutine xTo_Neumann
-
-
    subroutine xqo_convective
      use modglobal, only : ie, dxi, rk3step, dt
      use modfields, only : qt0, qtm, uouttot
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      qt0(ie + 1, :, :) = qt0(ie, :, :) - (qt0(ie + 1, :, :) - qt0(ie, :, :))*dxi*rk3coef*uouttot
      qtm(ie + 1, :, :) = qtm(ie, :, :) - (qtm(ie + 1, :, :) - qtm(ie, :, :))*dxi*rk3coef*uouttot
@@ -986,7 +958,7 @@ contains
      real rk3coef
      integer n
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        sv0(ie + 1, :, :, n) = sv0(ie + 1, :, :, n) - (sv0(ie + 1, :, :, n) - sv0(ie, :, :, n))*dxi*rk3coef*uouttot
@@ -994,24 +966,6 @@ contains
      end do
 
    end subroutine xso_convective
-
-
-   subroutine xso_Neumann
-     use modglobal, only : ie, ihc, rk3step, dt, nsv
-     use modfields, only :sv0, svm
-     real rk3coef
-     integer n, m
-
-     rk3coef = dt/(4.-dble(rk3step))
-
-     do n = 1, nsv
-       do m = 1, ihc
-         sv0(ie + m, :, :, n) = sv0(ie, :, :, n)
-         svm(ie + m, :, :, n) = svm(ie, :, :, n)
-       end do
-     end do
-
-   end subroutine xso_Neumann
 
 
    subroutine ymi_profile
@@ -1104,7 +1058,7 @@ contains
 
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      ! change to vouttot
      u0(:, je + 1, :) = u0(:, je + 1, :) - (u0(:, je + 1, :) - u0(:, je, :))*dyi*rk3coef*vouttot
@@ -1127,7 +1081,7 @@ contains
 
      real rk3coef
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      thl0(:, je + 1, :) = thl0(:, je + 1, :) - (thl0(:, je + 1, :) - thl0(:, je, :))*dyi*rk3coef*vouttot
      thlm(:, je + 1, :) = thlm(:, je + 1, :) - (thlm(:, je + 1, :) - thlm(:, je, :))*dyi*rk3coef*vouttot
@@ -1141,7 +1095,7 @@ contains
      use modfields, only : qt0, qtm, vouttot
 
      real rk3coef
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      qt0(:, je + 1, :) = qt0(:, je + 1, :) - (qt0(:, je + 1, :) - qt0(:, je, :))*dyi*rk3coef*vouttot
      qtm(:, je + 1, :) = qtm(:, je + 1, :) - (qtm(:, je + 1, :) - qtm(:, je, :))*dyi*rk3coef*vouttot
@@ -1157,7 +1111,7 @@ contains
      real rk3coef
      integer n
 
-     rk3coef = dt/(4.-dble(rk3step))
+     rk3coef = dt/(4.-real(rk3step))
 
      do n = 1, nsv
        sv0(:, je + 1, :, n) = sv0(:, je + 1, :, n) - (sv0(:, je + 1, :, n) - sv0(:, je, :, n))*dyi*rk3coef*vouttot
@@ -1165,26 +1119,6 @@ contains
      end do
 
    end subroutine yso_convective
-
-
-   subroutine yso_Neumann
-
-     use modglobal, only : je, jhc, rk3step, dt, nsv
-     use modfields, only : sv0, svm
-
-     real rk3coef
-     integer n, m
-
-     rk3coef = dt/(4.-dble(rk3step))
-
-     do n = 1, nsv
-       do m = 1, jhc
-         sv0(:, je + m, :, n) = sv0(:, je, :, n)
-         svm(:, je + m, :, n) = svm(:, je, :, n)
-       end do
-     end do
-
-   end subroutine yso_Neumann
 
 
    !>set boundary conditions pup,pvp,pwp in subroutine fillps in modpois.f90
@@ -1355,7 +1289,7 @@ contains
      if (rk3step == 0) then ! dt not defined yet
        rk3coef = 1.
      else
-       rk3coef = dt / (4. - dble(rk3step))
+       rk3coef = dt / (4. - real(rk3step))
      end if
      rk3coefi = 1. / rk3coef
 
@@ -1537,7 +1471,7 @@ contains
    end subroutine fluxtopscal
 
    subroutine valuetopscal(val)
-      use modglobal, only:ke, eps1, nsv, khc
+      use modglobal, only:ke, nsv, khc
       use modfields, only:sv0, svm
       real, intent(in)    :: val(1:nsv)
       integer :: m, n

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -926,6 +926,24 @@ contains
    end subroutine xmo_convective
 
 
+  !  subroutine xmo_Neumann
+  !    use modglobal,      only : ie
+  !    use modfields,      only : v0, vm, w0, wm, e120, e12m
+  !    use modsubgriddata, only : loneeqn
+
+  !    v0(ie + 1, :, :) = v0(ie, :, :)
+  !    w0(ie + 1, :, :) = w0(ie, :, :)
+  !    vm(ie + 1, :, :) = vm(ie, :, :)
+  !    wm(ie + 1, :, :) = wm(ie, :, :)
+
+  !    if (loneeqn) then
+  !      e120(ie + 1, :, :) = e120(ie, :, :)
+  !      e12m(ie + 1, :, :) = e12m(ie, :, :)
+  !    end if
+
+  !  end subroutine xmo_Neumann
+
+
    subroutine xTo_convective
      use modglobal, only : ie, dxi, rk3step, dt
      use modfields, only : thl0, thlm, uouttot
@@ -937,6 +955,16 @@ contains
      thlm(ie + 1, :, :) = thlm(ie+1, :, :) - (thlm(ie + 1, :, :) - thlm(ie, :, :))*dxi*rk3coef*uouttot
 
    end subroutine xTo_convective
+
+
+  !  subroutine xTo_Neumann
+  !    use modglobal, only : ie
+  !    use modfields, only : thl0, thlm
+
+  !    thl0(ie + 1, :, :) = thl0(ie, :, :)
+  !    thlm(ie + 1, :, :) = thlm(ie, :, :)
+
+  !  end subroutine xTo_Neumann
 
 
    subroutine xqo_convective
@@ -966,6 +994,24 @@ contains
      end do
 
    end subroutine xso_convective
+
+
+  !  subroutine xso_Neumann
+  !    use modglobal, only : ie, ihc, rk3step, dt, nsv
+  !    use modfields, only :sv0, svm
+  !    real rk3coef
+  !    integer n, m
+
+  !    rk3coef = dt/(4.-dble(rk3step))
+
+  !    do n = 1, nsv
+  !      do m = 1, ihc
+  !        sv0(ie + m, :, :, n) = sv0(ie, :, :, n)
+  !        svm(ie + m, :, :, n) = svm(ie, :, :, n)
+  !      end do
+  !    end do
+
+  !  end subroutine xso_Neumann
 
 
    subroutine ymi_profile
@@ -1119,6 +1165,26 @@ contains
      end do
 
    end subroutine yso_convective
+
+
+  !  subroutine yso_Neumann
+
+  !    use modglobal, only : je, jhc, rk3step, dt, nsv
+  !    use modfields, only : sv0, svm
+
+  !    real rk3coef
+  !    integer n, m
+
+  !    rk3coef = dt/(4.-dble(rk3step))
+
+  !    do n = 1, nsv
+  !      do m = 1, jhc
+  !        sv0(:, je + m, :, n) = sv0(:, je, :, n)
+  !        svm(:, je + m, :, n) = svm(:, je, :, n)
+  !      end do
+  !    end do
+
+  !  end subroutine yso_Neumann
 
 
    !>set boundary conditions pup,pvp,pwp in subroutine fillps in modpois.f90

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -157,37 +157,6 @@ contains
     return
   end subroutine calcdiffnr
 
-  !ils13, 13.08.18: currently unused, not called
-  !> tg3315 27/02/18 - was not outputting cell Peclet number so added this to give cell Reynolds number
-  subroutine calcreyn
-
-    use modglobal, only : ib,ie,jb,je,ke,kb,dy,dxh,dzh
-    use modfields, only : u0,v0,w0
-    use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,my_real,mpierr
-    use modsubgriddata, only : ekm
-    implicit none
-
-    real reyntotl,reyntot
-    integer       :: i,j,k
-
-    reyntotl = 0.
-    reyntot  = 0.
-    do k=kb,ke
-      do j=jb,je
-        do i=ib,ie
-      reyntotl = max(reyntotl,  u0(i,j,k) * dxh(i) / ekm(i,j,k), v0(i,j,k) * dy / ekm(i,j,k),  &
-                                    w0(i,j,k) * dzh(k) / ekm(i,j,k))  ! or should I interpolate ekm to the correct position?
-        end do
-      end do
-    end do
-
-    call MPI_ALLREDUCE(reyntotl,reyntot,1,MY_REAL,MPI_MAX,comm3d,mpierr)
-    if (myid==0) then
-      write(6,'(A,ES10.2)') 'Cell Reynolds number:',reyntot
-    end if
-
-  end subroutine calcreyn
-
 !> Checks local and total divergence
   subroutine chkdiv
 

--- a/src/moddriver.f90
+++ b/src/moddriver.f90
@@ -37,7 +37,7 @@ save
 
 contains
   subroutine initdriver
-    use modglobal, only : jh,jb,je,kb,ke,kh,jhc,khc,idriver,lchunkread,chunkread_size,iplane,ltempeq,lmoist,pi,driverstore,tdriverstart,tdriverdump,nsv,lhdriver,lqdriver,lsdriver,ibrank,iplanerank,driverid,cdriverid
+    use modglobal, only : jh,jb,je,kb,ke,kh,jhc,khc,idriver,lchunkread,chunkread_size,iplane,ltempeq,lmoist,driverstore,tdriverstart,tdriverdump,nsv,lhdriver,lqdriver,lsdriver,ibrank,iplanerank,driverid,cdriverid
     use modmpi, only : myidy,nprocy
     use decomp_2d, only : zstart, zend
 
@@ -173,8 +173,8 @@ contains
 
   subroutine drivergen
     use modglobal,   only : timee,btime,rk3step,&
-                            numol,idriver,&
-                            driverstore,prandtlmoli,numol,grav,&
+                            idriver,&
+                            driverstore,&
                             tdriverstart,dtdriver,tdriverdump,lchunkread,chunkread_size,ltempeq,lmoist,nsv,lhdriver,lqdriver,lsdriver,&
                             iplanerank,driverid,runtime,lwarmstart
     use modsave,     only : writerestartfiles
@@ -183,7 +183,7 @@ contains
 
     real :: elapsrec                            ! time elapsed in this inlet record
     real :: dtint                               ! dt for linear interpolation
-    real, PARAMETER :: eps = 1d-4
+    real, PARAMETER :: eps = 1e-4
     integer x,xc
 
     if (idriver == 1 .and. iplanerank) then
@@ -513,7 +513,7 @@ contains
   end subroutine drivergen
 
   subroutine writedriverfile
-    use modglobal, only : runtime,timee,tdriverstart,tdriverstart_cold,jb,je,jh,kb,ke,kh,cexpnr,ifoutput,ltempeq,lmoist,driverstore,dtdriver,nsv,driverid,cdriverid,btime,lwarmstart
+    use modglobal, only : runtime,timee,tdriverstart,tdriverstart_cold,jb,je,jh,kb,ke,kh,cexpnr,ltempeq,lmoist,driverstore,dtdriver,nsv,driverid,cdriverid,btime,lwarmstart
     use modfields, only : u0, v0, w0, thl0, qt0, sv0
     use modinletdata, only : nstepreaddriver
     implicit none
@@ -750,7 +750,7 @@ contains
   subroutine readdriverfile
     ! this gets called in modstartup (readinitfiles) when ibrank=.true.
     use modfields, only : u0,sv0
-    use modglobal, only : ib,jb,je,kb,ke,kh,jhc,khc,ifinput,driverstore,ltempeq,lmoist,jh,driverjobnr,cdriverjobnr,nsv,timee,tdriverstart,lhdriver,lqdriver,lsdriver,driverid,cdriverid,lwarmstart
+    use modglobal, only : ib,jb,je,kb,ke,kh,jhc,khc,driverstore,ltempeq,lmoist,jh,driverjobnr,cdriverjobnr,nsv,timee,tdriverstart,lhdriver,lqdriver,lsdriver,driverid,cdriverid,lwarmstart
     use modmpi,    only : slabsum,excjs
     use modinletdata, only : storetdriver,storeu0driver,storev0driver,storew0driver,storethl0driver,storeqt0driver,storesv0driver
     implicit none
@@ -932,7 +932,7 @@ contains
 
   subroutine readdriverfile_chunk
     use modfields, only : u0,sv0
-    use modglobal, only : ib,jb,je,kb,ke,kh,jhc,khc,ifinput,driverstore,chunkread_size,ltempeq,lmoist,jh,driverjobnr,cdriverjobnr,nsv,timee,tdriverstart,lhdriver,lqdriver,lsdriver,driverid,cdriverid,lwarmstart
+    use modglobal, only : ib,jb,je,kb,ke,kh,jhc,khc,driverstore,chunkread_size,ltempeq,lmoist,jh,driverjobnr,cdriverjobnr,nsv,timee,tdriverstart,lhdriver,lqdriver,lsdriver,driverid,cdriverid,lwarmstart
     use modmpi,    only : myid,slabsum,excjs
     use modinletdata, only : storetdriver,storeu0driver,storev0driver,storew0driver,storethl0driver,storeqt0driver,storesv0driver, &
                              chunkreadctr, chunkread_s, chunkread_e

--- a/src/modfielddump.f90
+++ b/src/modfielddump.f90
@@ -35,7 +35,7 @@ module modfielddump
   PUBLIC :: initfielddump, fielddump,exitfielddump
   save
   !NetCDF variables
-  integer :: ncid,ncid1,ncid2,nrec = 0
+  integer :: ncid,nrec = 0
 !  real, pointer :: point
   type domainptr
     real, pointer :: point(:,:,:)
@@ -43,12 +43,8 @@ module modfielddump
   type(domainptr), dimension(30) :: pfields
 
   character(80) :: fname = 'fielddump.xxx.xxx.xxx.nc'
-  character(80) :: fname1 = 'fielddump.xxx.xxx.xxx.1.nc'
-  character(80) :: fname2 = 'fielddump.xxx.xxx.xxx.2.nc'
   !dimension(nvar,4) :: ncname
   character(80),dimension(1,4) :: tncname
-  character(80),dimension(1,4) :: tncname1
-  character(80),dimension(1,4) :: tncname2
 
   integer :: ilow,ihigh,jlow,jhigh,klow,khigh,nvar
   logical :: ldiracc   = .false. !< switch for doing direct access writing (on/off)
@@ -59,7 +55,7 @@ contains
  !> Initializing fielddump. Read out the namelist, initializing the variables
   subroutine initfielddump
     use modmpi,   only   :mpierr,comm3d,mpi_logical,mpi_integer,cmyidx,cmyidy,mpi_character
-    use modglobal,only   :cexpnr,ifnamopt,kb,ke,fieldvars,ib,ie,jb,je,kb,ke, ih,jh,lfielddump,kh
+    use modglobal,only   :cexpnr,kb,ke,fieldvars,ib,ie,jb,je,kb,ke, ih,jh,lfielddump,kh
     use modstat_nc,only  : open_nc, define_nc,ncinfo,writestat_dims_nc
     use modfields, only  : u0,v0,w0,thl0,sv0,ql0,qt0,pres0,div,tau_x, tau_y, tau_z, thl_flux
     use modibm, only : mask_u, mask_v, mask_w, mask_c
@@ -383,7 +379,7 @@ contains
   !> Do fielddump. Collect data to truncated (2 byte) integers, and write them to file
   subroutine fielddump
     use modfields, only : u0,v0,w0,div,dudx,dvdy,dwdz  !ILS13 21.04.2015 changed to u0 from um  etc
-    use modglobal, only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,timee,ifoutput,&
+    use modglobal, only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,timee,&
                           tfielddump, tnextfielddump, lfielddump, rk3step,dyi,dxfi,dzhi
     !use modmpi,    only : myid,cmyid
     !use modsubgriddata, only : ekm,sbshr

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -136,7 +136,6 @@ module modforces
     use modglobal, only : ke,&
                           lvinf
     use modfields, only : u0av,v0av
-    use modmpi, only    : mpi_sum
     implicit none
     real, intent(out) :: freestream
 
@@ -177,7 +176,6 @@ module modforces
                           Uinf,ifixuinf,tscale,rk3step,inletav,&
                           freestreamav
     use modfields, only : dgdt
-    use modmpi, only    : mpi_sum
     implicit none
 
     real  utop,freestream
@@ -224,7 +222,6 @@ module modforces
                           Uinf,Vinf,ifixuinf,rk3step,&
                           lvinf
     use modfields, only : up,vp,u0av,v0av
-    use modmpi, only    : mpi_sum
     implicit none
 
     real  utop
@@ -235,7 +232,7 @@ module modforces
 
     if ((ifixuinf==1) .and. (rk3step==3)) then
 
-      ! rk3coef = dt / (4. - dble(rk3step))
+      ! rk3coef = dt / (4. - real(rk3step))
 
       ! do j =jb,je
       !   do i =ib,ie
@@ -291,7 +288,6 @@ module modforces
   end subroutine fixuinf1
 
   subroutine fixthetainf
-    use modmpi, only    : mpi_sum
     implicit none
 
     real  ttop
@@ -300,7 +296,7 @@ module modforces
 
     ! if (ifixuinf==1 .and. rk3step==3 .and. ltempeq) then !tg3315 commented
 
-    !   rk3coef = dt / (4. - dble(rk3step))
+    !   rk3coef = dt / (4. - real(rk3step))
 
     !   do j =jb,je
     !     do i =ib,ie
@@ -354,7 +350,7 @@ module modforces
     integer                       i,j,k
 
     if ((.not.linoutflow) .and. (luoutflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       ! Assumes ie=itot
@@ -396,7 +392,7 @@ module modforces
       uouttot = sum(uout(kb:ke))  ! mass flow rate at outlet
 
     elseif ((.not.linoutflow) .and. (luvolflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       udef = 0.
@@ -426,7 +422,7 @@ module modforces
     end if
 
     if ((.not.linoutflow) .and. (lvoutflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       ! Assumes je=jtot
@@ -470,7 +466,7 @@ module modforces
       end do
 
     elseif ((.not.linoutflow) .and. (lvvolflowr)) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       rk3coefi = 1 / rk3coef
 
       vdef = 0.
@@ -828,7 +824,7 @@ module modforces
   end subroutine lstend
 
   subroutine nudge
-    use modglobal,  only : kb,ke,lmoist,ltempeq,lnudge,lnudgevel,tnudge,nnudge,numol,nsv
+    use modglobal,  only : kb,ke,lmoist,ltempeq,lnudge,lnudgevel,tnudge,nnudge,nsv
     use modfields,  only : thlp,qtp,svp,sv0av,thl0av,qt0av,up,vp,u0av,v0av,uprof,vprof,thlprof,qtprof,svprof
     implicit none
     integer :: k, n
@@ -964,7 +960,7 @@ module modforces
       real :: vs, rk3coef
 
       if (ds > 0) then
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
       do i = ib,ie
          ig = i + zstart(1) - 1 ! global i position
          if (ig > int(itot/2)) then

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -1169,7 +1169,7 @@ module modibm
                            ib, ie, ih, ihc, jb, je, jh, jhc, kb, ke, kh, khc, nsv, totheatflux, totqflux, nfcts, rk3step, timee, nfcts, lwritefac, dt, dtfac, tfac, tnextfac
      use modfields, only : thl0, qt0, sv0, up, vp, wp, thlp, qtp, svp, &
                            tau_x, tau_y, tau_z, thl_flux
-     use modmpi, only : myid, MPI_SUM
+     use modmpi, only : myid
      use modstat_nc, only : writestat_nc, writestat_1D_nc, writestat_2D_nc
 
      real, allocatable :: rhs(:,:,:)
@@ -1285,7 +1285,7 @@ module modibm
 
    subroutine wallfunmom(dir, rhs, bound_info)
      use modglobal, only : ib, ie, ih, jb, je, jh, kb, ke, kh, xf, yf, zf, xh, yh, zh, &
-                           eps1, dx, dy, dzf, iwallmom, xhat, yhat, zhat, vec0, nfcts, lwritefac, rk3step
+                           dx, dy, dzf, iwallmom, xhat, yhat, zhat, vec0, nfcts, lwritefac, rk3step
      use modfields, only : u0, v0, w0, thl0
      use initfac,   only : facT, facz0, facz0h, facnorm, faca
      use decomp_2d, only : zstart
@@ -1434,7 +1434,7 @@ module modibm
 
 
    subroutine wallfunheat
-     use modglobal, only : ib, ie, jb, je, xf, yf, zf, xh, yh, zh, dx, dy, dzh, eps1, &
+     use modglobal, only : ib, ie, jb, je, xf, yf, zf, xh, yh, zh, dx, dy, dzh, &
                            xhat, yhat, zhat, vec0, ltempeq, lmoist, iwalltemp, iwallmoist, lEB, lwritefac, nfcts, rk3step, totheatflux, totqflux
      use modfields, only : u0, v0, w0, thl0, thlp, qt0, qtp, pres0
      use initfac,   only : facT, facz0, facz0h, facnorm, fachf, facef, facqsat, fachurel, facf, faclGR, faca
@@ -1999,8 +1999,8 @@ module modibm
       !kind of obsolete when road facets are being used
       !vegetated floor not added (could simply be copied from vegetated horizontal facets)
       use modwallfunctions, only:wfuno, wfmneutral
-      use modglobal, only:ib, ie, ih, jh, kb,ke,kh, jb, je, kb, numol, prandtlmol, nsv, &
-         dzf, dzfi, numoli, ltempeq, lmoist, BCbotT, BCbotq, BCbotm, BCbots, dzh2i
+      use modglobal, only:ib, ie, ih, jh, kb,ke,kh, jb, je, kb, nsv, &
+         dzf, dzfi, ltempeq, lmoist, BCbotT, BCbotq, BCbotm, BCbots, dzh2i
       use modfields, only : u0,v0,e120,e12m,thl0,qt0,sv0,up,vp,wp,thlp,qtp,svp,momfluxb,tfluxb,tau_x,tau_y,tau_z,thl_flux
       use modsurfdata, only:wtsurf, wqsurf, thls, z0, z0h
       use modsubgriddata, only:ekh

--- a/src/modinlet.f90
+++ b/src/modinlet.f90
@@ -263,7 +263,7 @@ contains
    ddispdxold   = ddispdx
 
    ! compute time-average velocities
-    rk3coef = dt / (4. - dble(rk3step))
+    rk3coef = dt / (4. - real(rk3step))
     if (rk3step==1) then
       deltat = rk3coef
     elseif (rk3step==2) then
@@ -862,7 +862,7 @@ contains
       t0inletbcold = t0inletbc
 
   ! determine time step interval in simulation
-      rk3coef   = dt / (4. - dble(rk3step))
+      rk3coef   = dt / (4. - real(rk3step))
       if (rk3step==1) then
         deltat = rk3coef
       elseif (rk3step==2) then
@@ -871,7 +871,7 @@ contains
         deltat = rk3coef - (dt/2.)
       end if
   ! determine time step interval in inlet data
-      rk3coefin = dtin / (4. - dble(rk3stepin))
+      rk3coefin = dtin / (4. - real(rk3stepin))
       if (rk3stepin==1) then
         dtinrk = rk3coefin
       elseif (rk3stepin==2) then
@@ -886,7 +886,7 @@ contains
         nstepread = nstepread +1
         elapstep = mod(elapstep,dtinrk)
         rk3stepin = mod(rk3stepin,3) + 1
-        rk3coefin = dtin / (4. - dble(rk3stepin))
+        rk3coefin = dtin / (4. - real(rk3stepin))
         if (rk3stepin==1) then
           dtinrk = rk3coefin
         elseif (rk3stepin==2) then
@@ -994,7 +994,7 @@ contains
    ddispdxold   = ddispdx
 
    ! compute time-average velocities
-    rk3coef = dt / (4. - dble(rk3step))
+    rk3coef = dt / (4. - real(rk3step))
     if (rk3step==1) then
       deltat = rk3coef
     elseif (rk3step==2) then
@@ -1383,7 +1383,7 @@ contains
       w0inletbcold = w0inletbc
 
   ! determine time step interval in simulation
-      rk3coef   = dt / (4. - dble(rk3step))
+      rk3coef   = dt / (4. - real(rk3step))
       if (rk3step==1) then
         deltat = rk3coef
       elseif (rk3step==2) then
@@ -1392,7 +1392,7 @@ contains
         deltat = rk3coef - (dt/2.)
       end if
   ! determine time step interval in inlet data
-      rk3coefin = dtin / (4. - dble(rk3stepin))
+      rk3coefin = dtin / (4. - real(rk3stepin))
       if (rk3stepin==1) then
         dtinrk = rk3coefin
       elseif (rk3stepin==2) then
@@ -1407,7 +1407,7 @@ contains
         nstepread = nstepread +1
         elapstep = mod(elapstep,dtinrk)
         rk3stepin = mod(rk3stepin,3) + 1
-        rk3coefin = dtin / (4. - dble(rk3stepin))
+        rk3coefin = dtin / (4. - real(rk3stepin))
         if (rk3stepin==1) then
           dtinrk = rk3coefin
         elseif (rk3stepin==2) then
@@ -1537,6 +1537,13 @@ contains
        real thlsdummy
        integer :: k
 
+       ! An isothermal inlet top (tinput(ke) exactly == thls) makes the enthalpy
+       ! -thickness denominator below exactly zero, which -ffpe-trap=zero turns
+       ! into a crash. Offsetting thls avoids that. The exact-equality test is
+       ! deliberate and must stay: a tolerance test would also capture merely
+       ! near-equal values, and clamping those to -0.000001 would flip the sign
+       ! of the denominator (and so of ethick) rather than just regularise it.
+       ! gfortran's -Wcompare-reals flags this; it is a false positive here.
        thlsdummy = thls
        if (tinput(ke) == thls) then
          thlsdummy = thls -0.000001
@@ -1547,6 +1554,10 @@ contains
 
        end do
        output   = sum(ethick)  ! enthalpy thickness
+       ! Callers divide by the enthalpy thickness, so an exactly-zero sum (an inlet
+       ! with no temperature deficit) is regularised rather than allowed to trap.
+       ! As above, the exact comparison is intended: only the exactly-zero case is
+       ! degenerate, and a small non-zero thickness is physically meaningful.
        if (output==0.) then
          output= 0.000001
        end if

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -50,9 +50,8 @@ save
   real, allocatable, target :: Fxy(:,:,:), Fxyz(:,:,:)
   real, allocatable :: xrt(:), yrt(:), zrt(:)
   real, allocatable, target :: xyzrt(:,:,:), bxyzrt(:,:,:)
-  real, allocatable :: a(:), b(:), c(:), ax(:), bx(:), cx(:) ! coefficients for tridiagonal matrix
-  real, allocatable :: pz_top(:,:,:), py_top(:,:,:), px_top(:,:,:)
-  integer :: ibc1, ibc2, kbc1, kbc2
+  real, allocatable :: a(:), b(:), c(:) ! coefficients for tridiagonal matrix
+  integer :: kbc1, kbc2
 
   integer(kind=selected_int_kind(18)) :: plan_r2fc_x, plan_r2fc_y, plan_fc2r_x, plan_fc2r_y
   integer(kind=selected_int_kind(18)) :: plan_r2fr_x, plan_r2fr_y, plan_fr2r_x, plan_fr2r_y
@@ -60,7 +59,6 @@ save
   real, allocatable :: Sxr(:), Sxfr(:), Syr(:), Syfr(:), Szr(:), Szfr(:)
   complex, allocatable :: Sxfc(:), Syfc(:)
   type(DECOMP_INFO) :: sp
-  type(DECOMP_INFO) :: decomp_top
   real, allocatable :: dpdztop(:,:)
   real, allocatable :: pij(:)
 
@@ -69,7 +67,7 @@ contains
     use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,imax,jmax,itot,jtot,ktot, &
                           dxi,dzh,dzf,dyi,dzfi,ipoiss,pi,&
                           POISS_FFT2D,POISS_FFT3D,POISS_CYC,POISS_FFT2D_2DECOMP,&
-                          BCxm,BCym,BCzp,BCtopm_pressure
+                          BCxm,BCym,BCzp
     use modfields, only : rhobf, rhobh
 
     implicit none
@@ -419,7 +417,7 @@ contains
   end subroutine initpois
 
   subroutine poisson
-    use modglobal, only : ib,ie,jb,je,kb,ke,itot,jtot,ktot,ipoiss,POISS_FFT2D,POISS_FFT3D,POISS_CYC,POISS_FFT2D_2DECOMP,imax,jmax,eps1,BCxm,BCym,BCzp
+    use modglobal, only : ib,ie,jb,je,kb,ke,itot,jtot,ktot,ipoiss,POISS_FFT2D,POISS_FFT3D,POISS_CYC,POISS_FFT2D_2DECOMP,imax,jmax,BCxm,BCym,BCzp
     use modmpi, only : barrou
     implicit none
     complex, allocatable, dimension(:,:,:) :: Fx, Fy, Fz
@@ -917,8 +915,7 @@ contains
 
 
     use modfields, only : up, vp, wp, um, vm, wm
-    use modglobal, only : rk3step, ib,ie,jb,je,kb,ke,dxi,dyi,dzfi,dt,&
-                          pi
+    use modglobal, only : rk3step, ib,ie,jb,je,kb,ke,dxi,dyi,dzfi,dt
     use modmpi,    only : excjs, avexy_ibm
     use modboundary, only: bcpup
 !    use modibm,    only : ibmnorm
@@ -935,7 +932,7 @@ contains
     if (rk3step == 0) then ! dt not defined yet
       rk3coef = 1.
     else
-      rk3coef = dt / (4. - dble(rk3step))
+      rk3coef = dt / (4. - real(rk3step))
     end if
     rk3coefi = 1. / rk3coef
 
@@ -1109,7 +1106,7 @@ contains
 
   subroutine solmpj(x)
     use modmpi,    only : barrou
-    use modglobal, only : imax,jmax,ktot,pi
+    use modglobal, only : imax,jmax,ktot
 
     implicit none
 

--- a/src/modsave.f90
+++ b/src/modsave.f90
@@ -42,7 +42,7 @@ contains
     use modfields, only : u0,v0,w0,thl0,qt0,ql0,ql0h,e120,sv0,mindist,wall,pres0
     use modglobal, only : ib,ie,ih,jb,je,jh,kb,ke,kh,trestart,tnextrestart,timee,&
                           cexpnr,rk3step,ifoutput,nsv,dt,ntrun,&
-                          iinletgen,timee,nstore,numol,grav
+                          iinletgen,timee,nstore
     use modmpi,    only : cmyidx,cmyidy,myid,slabsum,excjs,comm3d
     use modsubgriddata, only : ekm
     use modinletdata, only   : nstepread

--- a/src/modscalsource.f90
+++ b/src/modscalsource.f90
@@ -387,7 +387,7 @@ subroutine scalsource
   use modglobal,  only : pi,nsv,ib,ie,jb,je,kb,ke,zf,dx,dy,imax,jmax,&
                          xS,yS,zS,xSb,ySb,zSb,xSe,ySe,zSe,SS,sigS,lscasrc,lscasrcl,dzfi,nscasrc,scasrcp,nscasrcl,scasrcl
   use modfields,  only : svp
-  use modmpi,     only : myidx,myidy,MPI_SUM
+  use modmpi,     only : myidx,myidy
 
   implicit none
   integer :: i,j,k,n,ns

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -72,7 +72,6 @@ module modstartup
                                     lwallfunc,lprofforc,lchem,k1,JNO2,rv,rd,tnextEB,tEB,dtEB,bldT,flrT, lperiodicEBcorr, fraction,sinkbase,wsoil,wgrmax,wwilt,wfc,skyLW,GRLAI,rsmin,nfcts,lEB,lwriteEBfiles,nfaclyrs,lconstW,lvfsparse,nnz,lfacTlyrs, &
                                     BCxm,BCxT,BCxq,BCxs,BCym,BCyT,BCyq,BCys,BCzp,ds, &
                                     BCtopm,BCtopT,BCtopq,BCtops,BCbotm,BCbotT,BCbotq,BCbots, &
-                                    BCxm_periodic, BCym_periodic, &
                                     idriver,tdriverstart,driverjobnr,dtdriver,driverstore,lchunkread,chunkread_size, &
                                     lrandomize, prandtlturb, fkar, lwritefac, dtfac, tfac, tnextfac, &
                                     ltrees,ntrees,Qstar,dQdt,lad,lsize,r_s,cd,dec,ud,ltreedump,itree_mode, &
@@ -468,8 +467,8 @@ module modstartup
       call MPI_BCAST(lmintdump, 1, MPI_LOGICAL, 0, comm3d, mpierr) ! tg3315 added switch for writing statistics files
       call MPI_BCAST(ltkedump, 1, MPI_LOGICAL, 0, comm3d, mpierr) ! tg3315 added switch for writing tke budget files
       call MPI_BCAST(iplane, 1, MPI_INTEGER, 0, comm3d, mpierr) ! J.Tomas: ib+iplane is the i-plane that is stored if lstoreplane is .true.
-      call MPI_BCAST(startfile, 50, MPI_CHARACTER, 0, comm3d, mpierr)
-      call MPI_BCAST(author, 80, MPI_CHARACTER, 0, comm3d, mpierr)
+      call MPI_BCAST(startfile, len(startfile), MPI_CHARACTER, 0, comm3d, mpierr)
+      call MPI_BCAST(author, len(author), MPI_CHARACTER, 0, comm3d, mpierr)
       call MPI_BCAST(runtime, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(trestart, 1, MY_REAL, 0, comm3d, mpierr)
       call MPI_BCAST(tfielddump, 1, MY_REAL, 0, comm3d, mpierr)
@@ -483,7 +482,7 @@ module modstartup
       call MPI_BCAST(nsv, 1, MPI_INTEGER, 0, comm3d, mpierr)
       call MPI_BCAST(nscasrc,1,MPI_INTEGER,0,comm3d,mpierr)
       call MPI_BCAST(nscasrcl,1,MPI_INTEGER,0,comm3d,mpierr)
-      call MPI_BCAST(fieldvars, 50, MPI_CHARACTER, 0, comm3d, mpierr)
+      call MPI_BCAST(fieldvars, len(fieldvars), MPI_CHARACTER, 0, comm3d, mpierr)
       !call MPI_BCAST(nstat      ,1,MPI_INTEGER,0,comm3d,mpierr) !tg3315
       !call MPI_BCAST(ncstat     ,80,MPI_CHARACTER,0,comm3d,mpierr) !tg3315
       call MPI_BCAST(ifixuinf, 1, MPI_INTEGER, 0, comm3d, mpierr)
@@ -720,7 +719,7 @@ module modstartup
                               BCym_periodic, BCym_profile, BCyT_periodic, BCyT_profile, &
                               BCyq_periodic, BCyq_profile, &
                               linoutflow,ltempeq,iwalltemp,iwallmom,&
-                              ipoiss,POISS_FFT2D,POISS_FFT3D,POISS_CYC,&
+                              ipoiss,POISS_FFT2D,&
                               lydump,lytdump,luoutflowr,lvoutflowr,&
                               lhdriver,lqdriver,lsdriver,ltrees,lEB,itree_mode,&
                               TREE_MODE_DRAG_ONLY,TREE_MODE_SVEG,TREE_MODE_LEGACY_SEB
@@ -949,12 +948,12 @@ module modstartup
          v0av, u0av, qt0av, thl0av, qt0av, sv0av, &
          thlpcar, thvh, thvf, IIc, IIcs, IIu, IIus, IIv, IIvs, IIw, IIws, thl0c
             use modglobal,         only : ib,ie,ih,ihc,jb,je,jh,jhc,kb,ke,kh,khc,kmax,dtmax,dt,runtime,timeleft,timee,ntimee,ntrun,btime,dt_lim,nsv,&
-         zh, dzf, dzh, rv, rd, grav, cp, rlv, pref0, om23_gs, jgb, jge, Uinf, &
+         zh, dzf, dzh, rv, rd, cp, rlv, om23_gs, jgb, jge, Uinf, &
          e12min, dzh, cexpnr, ifinput, lwarmstart, lstratstart, trestart, numol, &
          ladaptive, tnextrestart, linoutflow, lper2inout, iinletgen, lreadminl, &
          ltempeq, prandtlmoli, &
          tnextfielddump, tfielddump, startfile, lprofforc,&
-         idriver,dtdriver,driverstore,tdriverstart,tdriverstart_cold,tdriverdump,lchunkread,ibrank,lrandomize,BCxs,BCxm_driver,&
+         idriver,dtdriver,driverstore,tdriverstart,tdriverstart_cold,tdriverdump,lchunkread,ibrank,lrandomize,BCxs,&
          tEB,tnextEB,dtEB,BCxs_custom,lEB,lfacTlyrs,tfac,tnextfac,dtfac
       use modsubgriddata, only:ekm, ekh, loneeqn
       use modsurfdata, only:thls, sv_top
@@ -1507,9 +1506,7 @@ module modstartup
                if (runtime < tdriverstart) then
                   if (myid==0) write(*,*) 'Warning! No driver files will be written as runtime < tdriverstart.'
                else
-                  if (trestart /= (tdriverstart + (driverstore-1)*dtdriver)) then
-                     trestart = (tdriverstart + (driverstore-1)*dtdriver)
-                  end if
+                  trestart = (tdriverstart + (driverstore-1)*dtdriver)
                   if (myid==0) then
                      write(*,'(A,F15.5)') 'Warning! for driver simulation, trestart gets set as &
                                            (tdriverstart + (driverstore-1)*dtdriver), ignoring the &
@@ -1698,9 +1695,7 @@ module modstartup
 
                   tdriverstart_cold = tdriverstart
                   tdriverstart = timee
-                  if (trestart /= (driverstore-1)*dtdriver) then
-                     trestart = (driverstore-1)*dtdriver
-                  end if
+                  trestart = (driverstore-1)*dtdriver
 
                   if (myid==0) then
                      write(*,'(A,F15.5)') "Warning! during warmstart of driver simulat ion, tdriverstart &
@@ -1716,9 +1711,7 @@ module modstartup
                   end if
 
                else ! if (timee<tdriverstart)
-                  if (trestart /= (tdriverstart + (driverstore-1)*dtdriver - btime)) then
-                     trestart = (tdriverstart + (driverstore-1)*dtdriver) - btime
-                  end if
+                  trestart = (tdriverstart + (driverstore-1)*dtdriver) - btime
                   if (myid==0) then
                      write(*,'(A,F15.5)') 'Warning! for this driver simulation, trestart gets set as &
                                            (tdriverstart + (driverstore-1)*dtdriver - btime), ignoring the &
@@ -2185,7 +2178,8 @@ module modstartup
       real, dimension(kbin:kein)          ::  Tinlin
       real, dimension(kbin:kein)          ::  Trecin
       real, dimension(kbin:kein + 1)        ::  Wrecin
-      character(50) :: name, name2, name4
+      character(len(startfile)) :: name
+      character(50) :: name2, name4
       real dummy
       integer i, j, k, n
       !********************************************************************

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -57,7 +57,9 @@ contains
     implicit none
     integer, intent (out) :: ncid,nrec
     integer, optional, intent (in) :: n1, n2, n3, ns, nfcts, nlyrs
-    character (len=40), intent (in) :: fname
+    ! Assumed length: every caller passes a character(80) name, so a fixed
+    ! len=40 here silently truncated any output filename over 40 characters.
+    character (len=*), intent (in) :: fname
 
     character (len=12):: date='',time=''
     integer :: iret,varid,ncall,RecordDimID
@@ -71,8 +73,8 @@ contains
 
       call date_and_time(date,time)
       !iret = nf90_create(fname,NF90_SHARE,ncid)
-      iret = nf90_create(fname,IOR(NF90_NETCDF4, NF90_SHARE),ncid)
-      iret = nf90_put_att(ncid,NF90_GLOBAL,'title',fname)
+      iret = nf90_create(trim(fname),IOR(NF90_NETCDF4, NF90_SHARE),ncid)
+      iret = nf90_put_att(ncid,NF90_GLOBAL,'title',trim(fname))
       iret = nf90_put_att(ncid,NF90_GLOBAL,'history','Created on '//trim(date)//' at '//trim(time))
       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Source',trim(version))
       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Author',trim(author))

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -45,8 +45,6 @@ contains
 
 
   subroutine initstat_nc
-    use modglobal, only : ifnamopt
-    use modmpi,    only : mpi_logical
     implicit none
 
   end subroutine initstat_nc
@@ -344,14 +342,12 @@ contains
    if (status /= nf90_noerr) call nchandle_error(status)
  end subroutine exitstat_nc
   subroutine writestat_dims_nc(ncid)
-    use modglobal, only : xf,xh,yf,yh,zf,zh,jmax,imax,dxh
+    use modglobal, only : xf,xh,yf,yh,zf,zh,jmax,imax
     use modmpi, only : myidx, myidy
     implicit none
     integer, intent(in) :: ncid
     integer             :: i=0,iret,length,varid
-    integer :: dx
 
-    dx = dxh(1) ! Assume equidistant grid
     !write(*,*) 'writestat_dims_nc'
     iret = nf90_inq_varid(ncid, 'xt', VarID)
     if (iret==0) iret=nf90_inquire_dimension(ncid, xtID, len=length)

--- a/src/modstatistics.f90
+++ b/src/modstatistics.f90
@@ -30,7 +30,7 @@ module modstatistics
   save
 
   !NetCDF variables
-  integer :: klow,khigh,i,j,k
+  integer :: i,j,k
 !  real    :: tsamplep,tstatsdumpp,tsample,tstatsdump
 
 contains
@@ -45,7 +45,6 @@ contains
                                upupav,vpvpav,wpwpav,upvpav,upwpav,vpwpav,thlpwpav
   use modglobal,        only : ib,ie,ih,jb,je,jh,ke,kb,kh,rk3step,&
                                ltempeq,dzf,dzhi
-  use modmpi,           only : mpi_sum
   implicit none
 
   real, dimension(ib-ih:ie+ih,jb-jh:je+jh,kb:ke+kh)     :: umint

--- a/src/modstatsdump.f90
+++ b/src/modstatsdump.f90
@@ -61,7 +61,7 @@ module modstatsdump
   character(80),dimension(1,4) :: tncstattr
   character(80),dimension(1,4) :: tncstatmint
 
-  integer :: klow,khigh,i,j,k
+  integer :: klow,khigh
   real    :: tsamplep,tstatsdumpp,tsample,tstatsdump
 
 
@@ -533,7 +533,7 @@ contains
                                ltreedump
 !  use modsubgriddata,   only : ekm,sbshr
   use modstat_nc,       only : writestat_nc,writestat_1D_nc
-  use modmpi,           only : myid,mpi_sum,avey_ibm,&
+  use modmpi,           only : myid,avey_ibm,&
                                avexy_ibm
   use modsubgrid,       only : ekh,ekm
   use modstatistics,    only : genstats,tkestats
@@ -1803,7 +1803,7 @@ contains
                                p_b,p_t,adv,IIc,IIcs
   use modglobal,        only : ib,ie,ih,jb,je,jh,ke,kb,kh,&
                                dzfi,dzhi,dxfi,dyi,dxhi,dy2i,grav,numol,ierank,jerank
-  use modmpi,           only : mpi_sum,avey_ibm,excjs,avexy_ibm
+  use modmpi,           only : avey_ibm,excjs,avexy_ibm
   use modsurfdata,      only : thls
   use decomp_2d,        only : exchange_halo_z
   implicit none

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -43,7 +43,7 @@ module modsubgrid
 contains
   subroutine initsubgrid
     use modglobal, only : ih,ib,ie,jh,jb,je,kb,ke,kh, &
-         pi,ifnamopt
+         pi
 
     implicit none
 
@@ -79,8 +79,8 @@ contains
   end subroutine initsubgrid
 
   subroutine subgridnamelist
-    use modglobal, only : pi,ifnamopt,fname_options,lles
-    use modmpi,    only : myid, comm3d, mpierr, my_real, mpi_logical, mpi_integer
+    use modglobal, only : ifnamopt,fname_options,lles
+    use modmpi,    only : myid, comm3d, mpierr, my_real, mpi_logical
 
     implicit none
 
@@ -190,12 +190,12 @@ contains
     !                                                                 |
     !-----------------------------------------------------------------|
 
-    use modglobal,   only : ib,ie,jb,je,kb,ke,delta,ekmin,grav,&
+    use modglobal,   only : ib,ie,jb,je,kb,ke,delta,grav,&
          dxi,dxiq,dx2,dy2,dyi,dyiq,dzf,dzf2,dzfi,dzhi, &
-         numol,numoli,prandtlmoli,dzfiq,lbuoyancy,dzh
+         numol,prandtlmoli,dzfiq,lbuoyancy,dzh
     use modfields,   only : dthvdz,e120,u0,v0,w0,thl0
     use modsurfdata, only : thvs
-    use modmpi,    only : excjs,mpi_sum,slabsumi
+    use modmpi,    only : excjs,slabsumi
     use modboundary, only : closurebc
     implicit none
 

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -363,7 +363,7 @@ contains
   !! \author Pier Siebesma   K.N.M.I.     06/01/1995
   subroutine fromztop
 
-    use modglobal, only : kb,ke,kh,dzf,dzh,rv,rd,cp,tmelt,zf,grav,pref0
+    use modglobal, only : kb,ke,kh,dzf,dzh,rv,rd,cp,zf,grav,pref0
     use modfields, only : qt0av,ql0av,presf,presh,thvh,thvf
     use modsurfdata,only : ps,thvs
     implicit none
@@ -506,7 +506,7 @@ contains
   !> Calculates the scalars at half levels.
   !! If the kappa advection scheme is active, interpolation needs to be done consistently.
   subroutine calc_halflev
-    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzf,dzh,iadv_kappa
+    use modglobal, only : ib,ie,jb,je,kb,ke,kh,dzf,dzh
     use modfields, only : thl0,thl0h,qt0,qt0h
     use modsurfdata,only: qts,thls
     implicit none

--- a/src/modtstep.f90
+++ b/src/modtstep.f90
@@ -188,7 +188,7 @@ subroutine tstep_integrate
   integer i,j,k,n
   real rk3coef,rk3coefi
 
-  rk3coef = dt / (4. - dble(rk3step))
+  rk3coef = dt / (4. - real(rk3step))
   rk3coefi = 1./rk3coef
 
   if(ifixuinf==2) then
@@ -230,7 +230,10 @@ subroutine tstep_integrate
     enddo
   end if
 
-  if (lchem .and. rk3coef == dt) then
+  ! Chemistry is applied once per full time step, on the last RK3 substep. This
+  ! used to be spelled `rk3coef == dt`, which holds only for rk3step==3 because
+  ! rk3coef = dt/(4-rk3step) -- true but obscure, and an exact real comparison.
+  if (lchem .and. rk3step == 3) then
     call chem
   end if
 
@@ -309,7 +312,6 @@ subroutine tstep_integrate
           if (ltempeq) then
             open(unit=11,file='thlsrc.txt',position='append')
             write(11,3002) timee,thlsrc
-3003        format (13(6e20.12))
             close(11)
           end if
 

--- a/src/vegetation.f90
+++ b/src/vegetation.f90
@@ -54,7 +54,7 @@ contains
   !! LAD/drag fields with halo exchanges, and precompute staggered face
   !! lists used by vegetation_forcing.
   subroutine init_vegetation
-    use modglobal,  only : ltrees,ltreedump,itree_mode,TREE_MODE_DRAG_ONLY,TREE_MODE_SVEG,TREE_MODE_LEGACY_SEB,ib,ie,jb,je,kb,ke,ih,jh,kh,cexpnr,nsv
+    use modglobal,  only : ltrees,ltreedump,itree_mode,TREE_MODE_SVEG,TREE_MODE_LEGACY_SEB,ib,ie,jb,je,kb,ke,ih,jh,kh,cexpnr,nsv
     use modmpi,     only : myid,comm3d,mpierr,MY_REAL
     use readinput,  only : read_sparse_ijk, read_sparse_real
     use decomp_2d,  only : exchange_halo_x, exchange_halo_y, exchange_halo_z
@@ -349,7 +349,7 @@ contains
   !! energy balance (heat/moisture), and scalar deposition.  Called once
   !! per timestep from the main time loop.
   subroutine vegetation_forcing
-    use modglobal,  only : lmoist,ltempeq,nsv,itree_mode,TREE_MODE_DRAG_ONLY,TREE_MODE_SVEG,TREE_MODE_LEGACY_SEB
+    use modglobal,  only : lmoist,ltempeq,nsv,itree_mode,TREE_MODE_SVEG,TREE_MODE_LEGACY_SEB
     use modfields,  only : um,vm,wm,up,vp,wp,svp,svm
     implicit none
     integer :: i,j,k,m,n,npts


### PR DESCRIPTION
## Why

The GNU (gfortran) debug build reported **130 warnings** where the Intel build reported none. #308 / #323 genuinely fixed the Intel remarks and they are still at zero — but gfortran's `-Wall -Wextra` enables classes Intel never reports (above all `-Wunused-parameter` for unused `use ... only:` imports). "Zero warnings" was only ever true for one compiler.

This takes GNU from **130 → 17**, with Intel still at 0. The 17 that remain are correct as they stand; see *What is deliberately left* below.

| Class | Before | After |
|---|---|---|
| `-Wunused-*` (parameter / value / function / label) | 80 | 2 |
| `-Wconversion` | 30 | **0** |
| `-Wcompare-reals` | 19 | 15 |
| `-Wcharacter-truncation` | 1 | **0** |

Counts are for the GNU debug build on GCC 12.3, which the Ubuntu runner reproduces exactly. Note that **each compiler sees a different set**: the macOS runner's Homebrew GCC 16 reported a further 16 `-Wcharacter-truncation` that neither GCC 12.3 nor Ubuntu's gfortran emits at all — those turned out to be a real bug and are fixed here too (§3). Verified 16 → 0 on macOS CI.

## What is in here

Chasing the warnings turned up four real bugs, not just noise.

### 1. `DOUBLE PRECISION` was silently quad precision

`-fdefault-real-8` **also widens `DOUBLE PRECISION` to 16 bytes** unless `-fdefault-double-8` is given. So every `dble(rk3step)` — including in the RK3 inner loop — was software-emulated **quadruple precision**, immediately truncated back to `real(8)` on assignment. That was the source of 24 of the 30 `-Wconversion` warnings.

Worse, Intel `-r8` keeps double at 8 bytes, so **the two builds disagreed about what `DOUBLE PRECISION` meant.** Verified with a `kind()` probe:

| Flags | `real` | `double precision` | `1d0` |
|---|---|---|---|
| Intel `-r8` | 8 | **8** | **8** |
| GNU `-fdefault-real-8` alone (master) | 8 | **16** | **16** |
| GNU + `-fdefault-double-8` (this PR) | 8 | **8** | **8** |

Fixed both ways: `-fdefault-double-8` restores toolchain parity, and all 26 `dble(...)` → `real(...)` plus `1d-4` → `1e-4` express the actual intent — the codebase has **zero** genuine `double precision` declarations, since `real` *is* the working 8-byte type under `-r8`.

### 2. `startfile` silently truncated to 50 chars (fixes #333)

`startfile` is `character(90)` user-facing namelist input, but was treated as 50 in two places:

```fortran
name = startfile                                    ! 90 -> 50, silent truncation
call MPI_BCAST(startfile, 50, MPI_CHARACTER, ...)   ! broadcasts 50 of 90
```

The broadcast is the nastier one: rank 0 opens the correct file while every other rank gets a truncated path — failing in a rank-dependent way that looks like a filesystem or decomposition problem. Both now derive from `len(startfile)`.

### 3. netCDF output filenames silently truncated to 40 chars

`open_nc` declared its filename dummy as `character(len=40)` while all 16 of its call sites pass a `character(80)` name, so any output filename over 40 characters was silently truncated — the same class as the `startfile` bug above. Current names are ~24 chars, so this was latent rather than active.

Now an assumed-length dummy, which no caller can outgrow. `open_nc` was the only fixed-length character dummy argument in `src/`, so this covers all 16 sites. Also added the missing `trim()` at the `nf90_create` / `nf90_put_att` calls — they were the only two of the four uses of `fname` without it. (The `title` global attribute is consequently written without trailing blanks; nothing reads it back.)

This one is **only visible on the macOS runner**, whose Homebrew GCC 16 reports `-Wcharacter-truncation`; neither GCC 12.3 nor the Ubuntu runner's gfortran emits that class at all. Confirmed 16 → 0 on macOS CI.

### 4. Two type errors

- `modstat_nc`: a local `integer :: dx` received the **real** grid spacing `dxh(1)`, truncating it (a spacing < 1.0 became 0). It was only ever read in commented-out code, so it is removed.
- `initfac`: `ivfsparse`/`jvfsparse` hold facet **indices** but were declared `real`, forcing a real→integer conversion at every use. Now `integer`, matching the `%d %d %.6f` layout that both the Python and MATLAB writers emit.

### 5. Unused symbols (80 → 2)

Unused `use ... only:` imports, unused PRIVATE module variables, four uncalled `*_Neumann` subroutines, `calcreyn`, and dead label 3003. The `*_Neumann` family was uncalled anywhere in `src/` and asymmetric (the `y` siblings never existed).

### 6. Real comparisons

Removed three idempotent `if (trestart /= E) trestart = E` guards — they cannot change behaviour, they only emit a warning. And `rk3coef == dt` → `rk3step == 3` in `modtstep`: equivalent, since `rk3coef = dt/(4-rk3step)`, and it matches the idiom already used at lines 287/327.

## What is deliberately left

- **2 `-Wunused-value`** are gfortran **false positives**: `tsample`/`tstatsdump` appear only in a `NAMELIST`, which gfortran does not count as a use. They are user-facing namelist input and must stay. (Removing them breaks the build — confirmed.)
- **15 `-Wcompare-reals`** are exact tests against sentinels that are set exactly (`timee == 0`, `cs == -1.`, the singular FFT mode). These are correct. gfortran warns on **any** real equality — including against named `parameter`s, so defining constants would not help (tested). Removing them would mean changing user-facing namelist defaults into logicals.
- The two `modinlet` guards are **documented rather than rewritten**: they regularise an exactly-zero denominator that `-ffpe-trap=zero` would crash on, and any tolerance test would flip the sign of near-zero values rather than just regularise them. The exact comparison is the only formulation preserving current behaviour.

## Reporting instead of a gate

No `-Werror` gate is included. One was built and verified, then deliberately dropped: CI does not pin its compilers (`apt install gfortran`, `brew install gcc` on rolling runner images), so a newer image can introduce warnings with no change to this repository — `-Werror` would then turn CI red on an unrelated PR rather than catch a regression. That is not hypothetical: the gate's list included `-Werror=character-truncation`, and the macOS runner had **16** hits in that class while the local and Ubuntu compilers reported zero. It would have failed on the first run. Pinning the compiler is the prerequisite for gating, and that is a separate decision.

Instead there is a **non-blocking diagnostic**: `.github/scripts/summarise_warnings.sh` counts each build's warnings by class into the GitHub step summary, listing the file:line of anything not already reviewed. It never fails the build, so it degrades gracefully — a new compiler just prints more rows. It handles both the gfortran (location header + `Warning:` line) and clang (single-line) formats.

This exists because the compilers genuinely disagree and that was invisible without downloading logs and grepping. Current output:

```
ubuntu-latest Debug:   17 warning(s), 0 actionable
macos-latest Debug:    17 warning(s), 0 actionable
ubuntu-latest Release:  0 warning(s), 0 actionable
```

`0 actionable` means everything left is in the reviewed-benign list (`-Wcompare-reals`, `-Wunused-value`); any non-zero number is worth a look. If a class there starts hiding real problems, drop it from the list rather than muting the report.

The build step also gains `set -o pipefail` — it overrides the default shell, which drops GitHub's `-eo pipefail`, so piping the build into `tee` would otherwise mask a failed build behind `tee`'s exit status.

## Review notes

- **This is a numerics change.** `dble` → `real` means RK3 coefficients now round from double rather than quad. Results should be identical or differ in the last ulp — the regression suite against master is the real check.
- Verified locally on GNU (GCC 12.3) and Intel (ifort 2021.2); both debug builds compile clean. CI's Ubuntu and macOS runners now both report `0 actionable`.
- **No tests are added.** There is no Fortran unit-test framework here (`tests/unit/` is a reserved stub containing only a README), and Fortran behaviour is verified end-to-end by building and comparing netCDF outputs. The regression covers the numerics change above — it built master and this branch and compared outputs (`PASS`) — but nothing exercises the truncation paths, since no case uses a filename long enough to trigger them. The fixes are structural (`len(startfile)`, assumed-length dummy) rather than new magic numbers, so they cannot drift the way the hardcoded 40/50 did; the warning summary is the backstop.
- Touches `modboundary`, `modibm`, `modpois`, `modstartup`, which #332 also rewrites — whichever lands second will need a rebase.
- Out of scope: the macOS runner also reports 11 **clang** warnings when building the bundled C `tools/View3D` (not Fortran, and #329 owns that area). Filed separately.
