### PR TITLE
Decouple periodicEBcorr volumetric heat sink from lEB dependency

### DIFF
--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -1545,8 +1545,9 @@ module modibm
          ! facet sensible heat flux = volumetric heat capacity of air * flux * sectionarea / facetarea [W/m^2]
          thlp(i,j,k) = thlp(i,j,k) - flux * area / (dx*dy*dzh(k))
 
+         totheatflux = totheatflux + flux*area ! [Km^3s^-1] This sums the flux over all facets (unconditional, mirrors totqflux; decouples periodicEBcorr from lEB)
+
          if (lEB) then
-           totheatflux = totheatflux + flux*area ! [Km^3s^-1] This sums the flux over all facets
            fachf(fac) = fachf(fac) + flux * area ! [Km^2/s] (will be divided by facetarea(fac) in modEB)
          end if !fachf=[Km/s]
        end if


### PR DESCRIPTION
Root cause: totheatflux accumulation in wallfunheat (modibm.f90) was gated by if(lEB), while the structurally identical totqflux was not. This caused periodicEBcorr's volumetric thlp correction to silently no-op whenever lEB=.false. (e.g. fixed-flux, non-SEB configurations), while its qtp correction continued to work normally.

Fix: move totheatflux accumulation outside if(lEB), mirroring totqflux. fachf (facet-level output, used only by modEB) remains gated by lEB.

Scope: verified applicable to iwalltemp=1 (fixed flux). For iwalltemp=2 (SEB/wall function), flux depends on facT, which is only updated when lEB=.true. (modEB.f90 EB subroutine short-circuits otherwise), so this fix does not make iwalltemp=2 + lEB=.false. physically meaningful.

Validated via case 016 (copy of 006, hm=8m, sinkbase=8, fraction=0.5, bctfz=-0.1, wttop=0, lEB=.false., lperiodicEBcorr=.true.), using a temporary diagnostic print (since reverted) to confirm tot_Tflux went from hard-coded 0 to -409.6, matching bctfz*(xlen*ylen) exactly. R_theta_scaled and phi_theta_t both matched hand-calculated values from the periodicEBcorr formula. Simulation ran stably to runtime=9100s (divmax/divtot at machine precision, no NaN/Inf).

Compiled and verified against current master (commit 4304489) using the default ARCHER2 environment (PrgEnv-cray, tools/build_executable.sh archer release) — 0 errors.