### PR TITLE
Accelerate and instrument direct shortwave preprocessing

### DIFF
--- a/tests/integration/udprep/test_scanline_contract.py
+++ b/tests/integration/udprep/test_scanline_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from udbase import UDBase
 _IMPORT_ERROR = None
 try:
     from udprep.directshortwave import DirectShortwaveSolver
+    from udprep.solar import nsun_from_angles
 except ImportError as exc:
     DirectShortwaveSolver = None
     _IMPORT_ERROR = exc
@@ -90,6 +92,28 @@ class TestScanlineContract(unittest.TestCase):
         np.testing.assert_allclose(vertices, inputs.vertices)
         np.testing.assert_allclose(faces, self.solver._scanline_face_rows(inputs))
         self.assertEqual(info_lines, self.solver._scanline_info_lines(inputs))
+
+    def test_optimized_extension_is_bitwise_stable(self) -> None:
+        fields = []
+        for zenith, azimuth in (
+            (0.0, 0.0),
+            (15.0, 20.0),
+            (45.0, 123.0),
+            (81.5, 189.0),
+        ):
+            sdir, _, _ = self.solver.compute(
+                nsun=nsun_from_angles(zenith, azimuth),
+                irradiance=800.0,
+                resolution=0.1,
+            )
+            fields.append(sdir)
+
+        # Captured from the original extension before the scanline optimization.
+        digest = hashlib.sha256(np.stack(fields).tobytes(order="C")).hexdigest()
+        self.assertEqual(
+            digest,
+            "19622e3efdb88b2870490554808e34794290c19f9975264df14d5c6c6a0da51f",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/integration/udprep/test_scanline_contract.py
+++ b/tests/integration/udprep/test_scanline_contract.py
@@ -59,6 +59,23 @@ class TestScanlineContract(unittest.TestCase):
         self.assertTrue(inputs.nsun.flags["F_CONTIGUOUS"])
         self.assertEqual(inputs.faces_1based.dtype, np.int32)
 
+    def test_static_scanline_geometry_is_reused_between_calls(self) -> None:
+        first = self.solver._build_scanline_inputs(self.nsun, 800.0, resolution=0.1)
+        second = self.solver._build_scanline_inputs(self.nsun, 700.0, resolution=0.2)
+
+        self.assertIs(first.faces_1based, second.faces_1based)
+        self.assertIs(first.facet_points, second.facet_points)
+        self.assertIs(first.face_normals, second.face_normals)
+        self.assertIs(first.vertices, second.vertices)
+        self.assertEqual(second.irradiance, 700.0)
+        self.assertEqual(second.resolution, 0.2)
+
+    def test_scanline_does_not_allocate_ray_casting_volume_fields(self) -> None:
+        self.assertEqual(self.solver.ktot, 0)
+        self.assertEqual(self.solver.lad_3d.size, 0)
+        self.assertEqual(self.solver.dec_3d.size, 0)
+        self.assertEqual(self.solver.veg_index.size, 0)
+
     def test_legacy_serialization_matches_canonical_inputs(self) -> None:
         inputs = self.solver._build_scanline_inputs(self.nsun, 800.0, resolution=0.1)
         with tempfile.TemporaryDirectory(prefix="udales-scanline-contract-") as td:

--- a/tools/SEB/directShortwave.f90
+++ b/tools/SEB/directShortwave.f90
@@ -90,18 +90,17 @@ contains
       real   , dimension(nFaces,3) :: planeIncenter
       real   , dimension(nFaces) :: areas, distIncenter, projAreas
       integer, dimension(nFaces) :: visibility, sortedFaces ! if visiblity is false then face is self-shaded, i.e. not visible to the sun
-      real   , dimension(nVertices,3) :: planeVertices, projVertices
+      real   , dimension(nVertices,3) :: planeVertices
       real   , dimension(nVertices,2) :: locVertices
-      real   , dimension(nVertices) :: distVertices
-      logical, dimension(:,:), allocatable :: mask
+      logical(kind=1), dimension(:,:), allocatable :: scratch
       integer, dimension(:,:), allocatable :: maskIDs
       real   , dimension(:), allocatable :: locCoord1, locCoord2
-      integer, dimension(:), allocatable :: counts
-      real :: xmin, xmax, xrange, ymin, ymax, yrange, temp
+      integer, dimension(:), allocatable :: counts, minY, maxY
+      real :: xmin, xmax, xrange, ymin, ymax, yrange
       real, dimension(3) :: p0, u1, u2, up
       real, dimension(2) :: cor1, cor2, cor3, cor4
       real, dimension(3,3) :: matrix, invMatrix
-      integer :: i, j, n, m, id_temp, size_xi, size_eta
+      integer :: i, j, n, m, size_xi, size_eta
       logical :: flag
       real :: start, finish
 
@@ -157,8 +156,6 @@ contains
 
       ! calculate areas and determine visiblity
 
-      sortedFaces(1) = 1
-
       do n=1,nFaces
          areas(n) = 0.5*norm2(cross_product(vertices(connectivityList(n,2),:) - vertices(connectivityList(n,1),:), &
                                             vertices(connectivityList(n,3),:) - vertices(connectivityList(n,1),:)))
@@ -166,25 +163,10 @@ contains
          if (dot_product(faceNormal(n,:), nsun) > 0)  visibility(n) = 1
          planeIncenter(n,:) = matmul(invMatrix, incenter(n,:) - p0)
          distIncenter(n) = planeIncenter(n,3)
-         !write(*,*) n, distIncenter(n)
-         ! sort
-         if (n > 1) then
-            m = n
-            do while (m > 1 .and. distIncenter(m) > distIncenter(m - 1)) ! note in descending order (>)
-            ! Swap array(m) and array(m - 1)
-            temp = distIncenter(m)
-            distIncenter(m) = distIncenter(m - 1)
-            distIncenter(m - 1) = temp
-            ! Update the corresponding index
-            id_temp = sortedFaces(m)
-            sortedFaces(m) = sortedFaces(m - 1)
-            sortedFaces(m - 1) = id_temp
-            m = m - 1
-            end do
-            ! Update the index for the newly inserted element
-            sortedFaces(m) = n
-         end if
+         sortedFaces(n) = n
       end do
+
+      call stableSortIndicesDescending(distIncenter, sortedFaces, nFaces)
 
       ! open (unit=11,file='sortedFaces_fort.txt',action="write")
       ! do n=1,nFaces
@@ -201,9 +183,6 @@ contains
 
       do n=1,nVertices
          planeVertices(n,:) = matmul(invMatrix, vertices(n,:) - p0)
-         distVertices(n) = planeVertices(n,3)
-         projVertices(n,:) = vertices(n,:) + distVertices(n) * nsun
-         !write(*,*) n, projVertices(n,:)
       end do
 
       locVertices(:,1) = planeVertices(:,1) + abs(minval(planeVertices(:,1)))
@@ -220,6 +199,10 @@ contains
       !allocate(mask(size_eta, size_xi))
       allocate(maskIDs(size_eta, size_xi))
       maskIDs = 0
+      allocate(scratch(size_eta, size_xi), minY(size_xi), maxY(size_xi))
+      scratch = .false._1
+      minY = 0
+      maxY = 0
 
       ! allocate(locCoord1(sizeMask1))
       ! allocate(locCoord2(sizeMask2))
@@ -287,7 +270,7 @@ contains
             !mask = .false.
             call poly2maskIDs(locVertices(connectivityList(m, :), 1) / resolution, &
                            locVertices(connectivityList(m, :), 2) / resolution, size_eta, &
-                           size_xi, maskIDs, m*visibility(m))
+                           size_xi, scratch, minY, maxY, maskIDs, m*visibility(m))
 
             ! call poly2maskIDs([locVertices(connectivityList(m, :), 1) / resolution, &
             !                    locVertices(connectivityList(m, 1), 1) / resolution], &
@@ -306,8 +289,8 @@ contains
 
       allocate(counts(nFaces))
       counts = 0
-      do i=1,size(maskIDs,1)
-         do j=1,size(maskIDs,2)
+      do j=1,size(maskIDs,2)
+         do i=1,size(maskIDs,1)
             if (maskIDs(i,j) > 0) counts(maskIDs(i,j)) = counts(maskIDs(i,j)) + 1
          end do
       end do
@@ -335,6 +318,53 @@ contains
       print '("Time = ",f10.3," seconds.")',finish-start
 
    end subroutine calculateDirectShortwave
+
+
+   subroutine stableSortIndicesDescending(values, indices, nValues)
+      integer, intent(in) :: nValues
+      real, intent(in) :: values(nValues)
+      integer, intent(inout) :: indices(nValues)
+      integer, allocatable :: work(:)
+      integer :: width, left, middle, right, i, j, k
+
+      if (nValues <= 1) return
+      allocate(work(nValues))
+
+      width = 1
+      do while (width < nValues)
+         left = 1
+         do while (left <= nValues)
+            middle = min(left + width - 1, nValues)
+            right = min(left + 2*width - 1, nValues)
+            i = left
+            j = middle + 1
+
+            do k=left,right
+               if (i > middle) then
+                  work(k) = indices(j)
+                  j = j + 1
+               else if (j > right) then
+                  work(k) = indices(i)
+                  i = i + 1
+               else if (values(indices(i)) >= values(indices(j))) then
+                  ! Prefer the left run for equal values to preserve input order.
+                  work(k) = indices(i)
+                  i = i + 1
+               else
+                  work(k) = indices(j)
+                  j = j + 1
+               end if
+            end do
+            indices(left:right) = work(left:right)
+            left = left + 2*width
+         end do
+
+         if (width > nValues/2) exit
+         width = 2*width
+      end do
+
+      deallocate(work)
+   end subroutine stableSortIndicesDescending
 
 
    subroutine writeDirectShortwave(Sdir, nFaces)
@@ -493,43 +523,38 @@ contains
   ! end subroutine poly2maskIDs
 
     !subroutine poly2maskIDs(xpt, ypt, M, N, out, outIDs, id)
-    subroutine poly2maskIDs(xpt, ypt, M, N, outIDs, id)
+    subroutine poly2maskIDs(xpt, ypt, M, N, out, minY, maxY, outIDs, id)
         real  , intent(in) :: xpt(:), ypt(:) ! assumes x(end) != x(1)
-        real, allocatable, dimension(:) :: x, y
+        real :: x(size(xpt) + 1), y(size(ypt) + 1)
         integer, intent(in) :: M, N, id
-        !logical, intent(out) :: out(M, N)
-        logical :: out(M, N)
+        logical(kind=1), intent(inout) :: out(M, N)
+        integer, intent(inout) :: minY(N), maxY(N)
         integer, intent(inout) :: outIDs(M, N)
-        integer :: sizeX
+        integer :: sizeX, cmin, cmax
         real    :: scale = 5.0
-        integer :: minY(N), maxY(N)
 
-        ! Initialize
-        out = .false.
-        minY = 0
-        maxY = 0
+        cmin = N + 1
+        cmax = 0
         sizeX = size(xpt,1)+1 ! number of vertices
-        allocate(x(sizeX), y(sizeX))
         x(1:sizeX-1) = xpt
         y(1:sizeX-1) = ypt
         x(sizeX) = xpt(1)
         y(sizeX) = ypt(1)
 
         ! Create edges in mask to be used during parity scan
-        call poly2edgelist(x, y, sizeX, scale, M, N, out, minY, maxY)
+        call poly2edgelist(x, y, sizeX, scale, M, N, out, minY, maxY, cmin, cmax)
         ! Perform the parity scan over the output mask 'out'
-        call parityScan(out, N, minY, maxY, outIDs, id)
-
-        deallocate(x, y)
+        call parityScan(out, N, minY, maxY, outIDs, id, cmin, cmax)
 
     end subroutine poly2maskIDs
 
-    subroutine poly2edgelist(x, y, xLength, scale, M, N, out, minY, maxY)
+    subroutine poly2edgelist(x, y, xLength, scale, M, N, out, minY, maxY, cmin, cmax)
         real  , intent(inout) :: x(:), y(:)
         integer, intent(in) :: xLength, M, N
         real   , intent(in) :: scale
-        logical, intent(inout) :: out(M, N)
+        logical(kind=1), intent(inout) :: out(M, N)
         integer, intent(inout) :: minY(N), maxY(N)
+        integer, intent(inout) :: cmin, cmax
         real, allocatable, dimension(:) :: xLinePts, yLinePts
         integer :: borderSize
         integer :: i, pt, xUse, yUse
@@ -568,9 +593,11 @@ contains
                 xLinePts(pt) = scaledDown
                 yLinePts(pt) = ceiling((yLinePts(pt) + (scale - 1.0) / 2.0) / scale)
                 ! Set xUse and yUse to these scaled down x and y values for indexing into the boolean array.
-                xUse = nint(xLinePts(pt)) + 1
-                yUse = nint(yLinePts(pt)) + 1
+               xUse = nint(xLinePts(pt)) + 1
+               yUse = nint(yLinePts(pt)) + 1
                if (.not. (xUse < 2 .or. xUse > N + 1)) then
+                 cmin = min(cmin, xUse - 1)
+                 cmax = max(cmax, xUse - 1)
                  if (yUse > M + 1) then
                    if (minY(xUse - 1) == 0) then
                      minY(xUse - 1) = M + 1
@@ -746,29 +773,25 @@ contains
         end if
     end subroutine intLine
 
-    subroutine parityScan(out, N, minY, maxY, outIDs, id)
-        logical, intent(inout) :: out(:,:)
+    subroutine parityScan(out, N, minY, maxY, outIDs, id, cmin, cmax)
+        logical(kind=1), intent(inout) :: out(:,:)
         integer, intent(inout) :: outIDs(:,:)
-        integer, intent(in) :: N, id
-        integer, intent(in) :: minY(N), maxY(N)
+        integer, intent(in) :: N, id, cmin, cmax
+        integer, intent(inout) :: minY(N), maxY(N)
         logical :: pixel
-        integer :: c, r!, id_first, id_last
+        integer :: c, r, rhi
 
-        do c = 1, N
+        do c = cmin, cmax
+            if (maxY(c) == 0) cycle
+            rhi = min(maxY(c) - 1, size(out, 1))
             pixel = .false.
-            do r = minY(c), maxY(c) - 1
+            do r = minY(c), rhi
                 if (out(r, c)) pixel = .not. pixel
-                out(r, c) = pixel
-                if (out(r,c)) outIDs(r, c) = id
+                out(r, c) = .false._1
+                if (pixel) outIDs(r, c) = id
             end do
-            ! if (maxY(c) > 0) then
-            !    id_first = findloc(out(minY(c):maxY(c)-1,c), .true., 1) + minY(c) - 1
-            !    id_last  = findloc(out(minY(c):maxY(c)-1,c), .true., 1, back=.true.) + minY(c) - 1
-            !    out(id_last, c) = .false.
-            !    if (id_first+1 <= id_last-1) then
-            !       out(id_first+1:id_last-1, c) = .true.
-            !    end if
-            ! end if
+            minY(c) = 0
+            maxY(c) = 0
         end do
     end subroutine parityScan
 

--- a/tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py
+++ b/tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py
@@ -109,6 +109,23 @@ def parse_args() -> argparse.Namespace:
             "<PREFIX>.summary.json."
         ),
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of independent facet timestamps to compute concurrently.",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        default=None,
+        help="Write one atomic checkpoint per completed radiation timestamp.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Reuse compatible completed timestamps from --checkpoint-dir.",
+    )
     parser.add_argument("--quiet", action="store_true")
     return parser.parse_args()
 
@@ -130,6 +147,9 @@ def main() -> int:
             method=args.method,
             verbose=not args.quiet,
             timing_prefix=args.timing_prefix,
+            workers=args.workers,
+            checkpoint_dir=args.checkpoint_dir,
+            resume=args.resume,
         )
     except (RuntimeError, FileExistsError, FileNotFoundError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py
+++ b/tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py
@@ -100,6 +100,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Replace existing timedepsw/netsw/Sdir outputs.",
     )
+    parser.add_argument(
+        "--timing-prefix",
+        type=Path,
+        default=None,
+        help=(
+            "Write benchmark progress to <PREFIX>.timestamps.csv and "
+            "<PREFIX>.summary.json."
+        ),
+    )
     parser.add_argument("--quiet", action="store_true")
     return parser.parse_args()
 
@@ -120,6 +129,7 @@ def main() -> int:
             atmos_only=args.atmos_only,
             method=args.method,
             verbose=not args.quiet,
+            timing_prefix=args.timing_prefix,
         )
     except (RuntimeError, FileExistsError, FileNotFoundError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -141,6 +151,9 @@ def main() -> int:
         print(f"Wrote {result.sdir_nc_path}")
     if result.timedepsveg_path is not None:
         print(f"Wrote {result.timedepsveg_path}")
+    if args.timing_prefix is not None:
+        print(f"Wrote {args.timing_prefix}.timestamps.csv")
+        print(f"Wrote {args.timing_prefix}.summary.json")
     return 0
 
 

--- a/tools/python/examples/harmonie_to_udales_radiation/harmonie_to_udales_radiation_workflow.ipynb
+++ b/tools/python/examples/harmonie_to_udales_radiation/harmonie_to_udales_radiation_workflow.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "workflow-title",
    "metadata": {},
    "source": [
     "# HARMONIE to uDALES Radiation Inputs\n",
@@ -156,7 +157,7 @@
    "source": [
     "## 4. Generate `timedepsw.inp.300`\n",
     "\n",
-    "Run after standard preprocessing has finished and the combined Python environment is active."
+    "Run after standard preprocessing has finished and the combined Python environment is active. Experiment 300 uses `ishortwave=1` (`scanline_f2py`), so `--workers 8` computes eight independent timestamps concurrently. `NUMBA_NUM_THREADS=1` prevents nested CPU threading inside each worker. Use either the foreground cell or the headless `nohup` cell below, not both."
    ]
   },
   {
@@ -169,9 +170,50 @@
     "%%bash\n",
     "set -euo pipefail\n",
     "cd /home/dipanjan/simulation/udtest/u-dales\n",
-    "tools/python/.venv/bin/python tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py \\\n",
-    "  --case-dir /home/dipanjan/simulation/udtest/experiments/300 \\\n",
+    "CASE=/home/dipanjan/simulation/udtest/experiments/300\n",
+    "NUMBA_NUM_THREADS=1 tools/python/.venv/bin/python -u tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py \\\n",
+    "  --case-dir \"$CASE\" \\\n",
+    "  --workers 8 \\\n",
+    "  --checkpoint-dir \"$CASE/harmonie_ssrd.checkpoints\" \\\n",
+    "  --resume \\\n",
+    "  --timing-prefix \"$CASE/harmonie_ssrd\" \\\n",
     "  --overwrite\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "headless-shortwave",
+   "metadata": {},
+   "source": [
+    "### Headless `nohup` Run\n",
+    "\n",
+    "Use this cell instead of the preceding foreground cell when the process must continue after closing the terminal or disconnecting the remote session. Progress is written immediately to the log because Python runs unbuffered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "headless-shortwave-command",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "cd /home/dipanjan/simulation/udtest/u-dales\n",
+    "CASE=/home/dipanjan/simulation/udtest/experiments/300\n",
+    "LOG=\"$CASE/harmonie_ssrd_to_timedepsw.log\"\n",
+    "PIDFILE=\"$CASE/harmonie_ssrd_to_timedepsw.pid\"\n",
+    "nohup env NUMBA_NUM_THREADS=1 tools/python/.venv/bin/python -u tools/python/examples/harmonie_to_udales_radiation/harmonie_ssrd_to_timedepsw.py \\\n",
+    "  --case-dir \"$CASE\" \\\n",
+    "  --workers 8 \\\n",
+    "  --checkpoint-dir \"$CASE/harmonie_ssrd.checkpoints\" \\\n",
+    "  --resume \\\n",
+    "  --timing-prefix \"$CASE/harmonie_ssrd\" \\\n",
+    "  --overwrite \\\n",
+    "  > \"$LOG\" 2>&1 < /dev/null &\n",
+    "PID=$!\n",
+    "printf '%s\\n' \"$PID\" > \"$PIDFILE\"\n",
+    "printf 'Started PID %s\\nLog: %s\\nPID file: %s\\n' \"$PID\" \"$LOG\" \"$PIDFILE\"\n"
    ]
   },
   {
@@ -182,9 +224,12 @@
     "Expected outputs:\n",
     "\n",
     "- `/home/dipanjan/simulation/udtest/experiments/300/timedepsw.inp.300`\n",
+    "- `/home/dipanjan/simulation/udtest/experiments/300/netsw.inp.300`\n",
     "- `/home/dipanjan/simulation/udtest/experiments/300/Sdir.nc`\n",
+    "- `/home/dipanjan/simulation/udtest/experiments/300/harmonie_ssrd.timestamps.csv`\n",
+    "- `/home/dipanjan/simulation/udtest/experiments/300/harmonie_ssrd.summary.json`\n",
     "\n",
-    "The `timedepsw` file stores net absorbed shortwave per facet in W/m2. The second line contains 181 times; then one row per facet follows."
+    "The `timedepsw` file stores net absorbed shortwave per facet in W/m2. The second line contains 181 times; then one row per facet follows. Completed timestamps are stored atomically under `harmonie_ssrd.checkpoints`, allowing the same command to resume after interruption."
    ]
   },
   {
@@ -282,6 +327,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "workflow-notes",
    "metadata": {},
    "source": [
     "## Notes\n",
@@ -290,7 +336,9 @@
     "- `--download` calls the NWP demo downloader and may download much more than the single radiation field.\n",
     "- The central Paris domain is fixed by default to EPSG:2154 easting `649375..652600 m` and northing `6861175..6864020 m`.\n",
     "- Shortwave uses an empirical Erbs direct/diffuse split because the available HARMONIE files include `ssrd` but not a direct-normal or diffuse-only shortwave field.\n",
-    "- Run the NWP radiation scripts after standard preprocessing, not before."
+    "- Run the NWP radiation scripts after standard preprocessing, not before.\n",
+    "- `--workers` controls independent timestamp processes and defaults to 1. The recommended value here is 8 for experiment 300's `scanline_f2py` method.\n",
+    "- For `--method facsec` or `--method moller`, use `--workers 1` with `NUMBA_NUM_THREADS=8` so Numba parallelizes rays within one timestamp without nested oversubscription."
    ]
   }
  ],

--- a/tools/python/fortran/directShortwave.f90
+++ b/tools/python/fortran/directShortwave.f90
@@ -54,7 +54,6 @@ contains
       real, dimension(3,3) :: matrix, invMatrix
       integer :: i, j, n, m, size_xi, size_eta
       logical :: flag
-      real :: start, finish
 
       ! projection
       xmin = minval(vertices(:,1))
@@ -213,8 +212,6 @@ contains
          !    end do
          ! end do
 
-         call cpu_time(start)
-
          ! polygon scan conversion
          do n=1,nFaces
            !write(*,*) "n", n
@@ -256,8 +253,6 @@ contains
       ! end do
       ! close (11)
 
-            call cpu_time(finish)
-
       projAreas = counts * resolution**2
 
       Sdir = irradiance * projAreas / areas
@@ -266,8 +261,6 @@ contains
       ! do n=1,1000
       !    write(*,*) n, counts(n), projAreas(n), Sdir(n)
       ! end do
-
-      print '("Time = ",f10.3," seconds.")',finish-start
 
    end subroutine calculateDirectShortwave
 

--- a/tools/python/fortran/directShortwave.f90
+++ b/tools/python/fortran/directShortwave.f90
@@ -44,10 +44,10 @@ contains
       integer, dimension(nFaces) :: visibility, sortedFaces ! if visiblity is false then face is self-shaded, i.e. not visible to the sun
       real   , dimension(nVertices,3) :: planeVertices
       real   , dimension(nVertices,2) :: locVertices
-      logical, dimension(:,:), allocatable :: mask
+      logical(kind=1), dimension(:,:), allocatable :: scratch
       integer, dimension(:,:), allocatable :: maskIDs
       real   , dimension(:), allocatable :: locCoord1, locCoord2
-      integer, dimension(:), allocatable :: counts
+      integer, dimension(:), allocatable :: counts, minY, maxY
       real :: xmin, xmax, xrange, ymin, ymax, yrange
       real, dimension(3) :: p0, u1, u2, up
       real, dimension(2) :: cor1, cor2, cor3, cor4
@@ -151,6 +151,10 @@ contains
       !allocate(mask(size_eta, size_xi))
       allocate(maskIDs(size_eta, size_xi))
       maskIDs = 0
+      allocate(scratch(size_eta, size_xi), minY(size_xi), maxY(size_xi))
+      scratch = .false._1
+      minY = 0
+      maxY = 0
 
       ! allocate(locCoord1(sizeMask1))
       ! allocate(locCoord2(sizeMask2))
@@ -218,7 +222,7 @@ contains
             !mask = .false.
             call poly2maskIDs(locVertices(connectivityList(m, :), 1) / resolution, &
                            locVertices(connectivityList(m, :), 2) / resolution, size_eta, &
-                           size_xi, maskIDs, m*visibility(m))
+                           size_xi, scratch, minY, maxY, maskIDs, m*visibility(m))
 
             ! call poly2maskIDs([locVertices(connectivityList(m, :), 1) / resolution, &
             !                    locVertices(connectivityList(m, 1), 1) / resolution], &
@@ -237,8 +241,8 @@ contains
 
       allocate(counts(nFaces))
       counts = 0
-      do i=1,size(maskIDs,1)
-         do j=1,size(maskIDs,2)
+      do j=1,size(maskIDs,2)
+         do i=1,size(maskIDs,1)
             if (maskIDs(i,j) > 0) counts(maskIDs(i,j)) = counts(maskIDs(i,j)) + 1
          end do
       end do
@@ -471,43 +475,38 @@ contains
   ! end subroutine poly2maskIDs
 
     !subroutine poly2maskIDs(xpt, ypt, M, N, out, outIDs, id)
-    subroutine poly2maskIDs(xpt, ypt, M, N, outIDs, id)
+    subroutine poly2maskIDs(xpt, ypt, M, N, out, minY, maxY, outIDs, id)
         real  , intent(in) :: xpt(:), ypt(:) ! assumes x(end) != x(1)
-        real, allocatable, dimension(:) :: x, y
+        real :: x(size(xpt) + 1), y(size(ypt) + 1)
         integer, intent(in) :: M, N, id
-        !logical, intent(out) :: out(M, N)
-        logical :: out(M, N)
+        logical(kind=1), intent(inout) :: out(M, N)
+        integer, intent(inout) :: minY(N), maxY(N)
         integer, intent(inout) :: outIDs(M, N)
-        integer :: sizeX
+        integer :: sizeX, cmin, cmax
         real    :: scale = 5.0
-        integer :: minY(N), maxY(N)
 
-        ! Initialize
-        out = .false.
-        minY = 0
-        maxY = 0
+        cmin = N + 1
+        cmax = 0
         sizeX = size(xpt,1)+1 ! number of vertices
-        allocate(x(sizeX), y(sizeX))
         x(1:sizeX-1) = xpt
         y(1:sizeX-1) = ypt
         x(sizeX) = xpt(1)
         y(sizeX) = ypt(1)
 
         ! Create edges in mask to be used during parity scan
-        call poly2edgelist(x, y, sizeX, scale, M, N, out, minY, maxY)
+        call poly2edgelist(x, y, sizeX, scale, M, N, out, minY, maxY, cmin, cmax)
         ! Perform the parity scan over the output mask 'out'
-        call parityScan(out, N, minY, maxY, outIDs, id)
-
-        deallocate(x, y)
+        call parityScan(out, N, minY, maxY, outIDs, id, cmin, cmax)
 
     end subroutine poly2maskIDs
 
-    subroutine poly2edgelist(x, y, xLength, scale, M, N, out, minY, maxY)
+    subroutine poly2edgelist(x, y, xLength, scale, M, N, out, minY, maxY, cmin, cmax)
         real  , intent(inout) :: x(:), y(:)
         integer, intent(in) :: xLength, M, N
         real   , intent(in) :: scale
-        logical, intent(inout) :: out(M, N)
+        logical(kind=1), intent(inout) :: out(M, N)
         integer, intent(inout) :: minY(N), maxY(N)
+        integer, intent(inout) :: cmin, cmax
         real, allocatable, dimension(:) :: xLinePts, yLinePts
         integer :: borderSize
         integer :: i, pt, xUse, yUse
@@ -546,9 +545,11 @@ contains
                 xLinePts(pt) = scaledDown
                 yLinePts(pt) = ceiling((yLinePts(pt) + (scale - 1.0) / 2.0) / scale)
                 ! Set xUse and yUse to these scaled down x and y values for indexing into the boolean array.
-                xUse = nint(xLinePts(pt)) + 1
-                yUse = nint(yLinePts(pt)) + 1
+               xUse = nint(xLinePts(pt)) + 1
+               yUse = nint(yLinePts(pt)) + 1
                if (.not. (xUse < 2 .or. xUse > N + 1)) then
+                 cmin = min(cmin, xUse - 1)
+                 cmax = max(cmax, xUse - 1)
                  if (yUse > M + 1) then
                    if (minY(xUse - 1) == 0) then
                      minY(xUse - 1) = M + 1
@@ -724,29 +725,25 @@ contains
         end if
     end subroutine intLine
 
-    subroutine parityScan(out, N, minY, maxY, outIDs, id)
-        logical, intent(inout) :: out(:,:)
+    subroutine parityScan(out, N, minY, maxY, outIDs, id, cmin, cmax)
+        logical(kind=1), intent(inout) :: out(:,:)
         integer, intent(inout) :: outIDs(:,:)
-        integer, intent(in) :: N, id
-        integer, intent(in) :: minY(N), maxY(N)
+        integer, intent(in) :: N, id, cmin, cmax
+        integer, intent(inout) :: minY(N), maxY(N)
         logical :: pixel
-        integer :: c, r!, id_first, id_last
+        integer :: c, r, rhi
 
-        do c = 1, N
+        do c = cmin, cmax
+            if (maxY(c) == 0) cycle
+            rhi = min(maxY(c) - 1, size(out, 1))
             pixel = .false.
-            do r = minY(c), maxY(c) - 1
+            do r = minY(c), rhi
                 if (out(r, c)) pixel = .not. pixel
-                out(r, c) = pixel
-                if (out(r,c)) outIDs(r, c) = id
+                out(r, c) = .false._1
+                if (pixel) outIDs(r, c) = id
             end do
-            ! if (maxY(c) > 0) then
-            !    id_first = findloc(out(minY(c):maxY(c)-1,c), .true., 1) + minY(c) - 1
-            !    id_last  = findloc(out(minY(c):maxY(c)-1,c), .true., 1, back=.true.) + minY(c) - 1
-            !    out(id_last, c) = .false.
-            !    if (id_first+1 <= id_last-1) then
-            !       out(id_first+1:id_last-1, c) = .true.
-            !    end if
-            ! end if
+            minY(c) = 0
+            maxY(c) = 0
         end do
     end subroutine parityScan
 

--- a/tools/python/fortran/directShortwave.f90
+++ b/tools/python/fortran/directShortwave.f90
@@ -42,18 +42,17 @@ contains
       real   , dimension(nFaces,3) :: planeIncenter
       real   , dimension(nFaces) :: areas, distIncenter, projAreas
       integer, dimension(nFaces) :: visibility, sortedFaces ! if visiblity is false then face is self-shaded, i.e. not visible to the sun
-      real   , dimension(nVertices,3) :: planeVertices, projVertices
+      real   , dimension(nVertices,3) :: planeVertices
       real   , dimension(nVertices,2) :: locVertices
-      real   , dimension(nVertices) :: distVertices
       logical, dimension(:,:), allocatable :: mask
       integer, dimension(:,:), allocatable :: maskIDs
       real   , dimension(:), allocatable :: locCoord1, locCoord2
       integer, dimension(:), allocatable :: counts
-      real :: xmin, xmax, xrange, ymin, ymax, yrange, temp
+      real :: xmin, xmax, xrange, ymin, ymax, yrange
       real, dimension(3) :: p0, u1, u2, up
       real, dimension(2) :: cor1, cor2, cor3, cor4
       real, dimension(3,3) :: matrix, invMatrix
-      integer :: i, j, n, m, id_temp, size_xi, size_eta
+      integer :: i, j, n, m, size_xi, size_eta
       logical :: flag
       real :: start, finish
 
@@ -109,8 +108,6 @@ contains
 
       ! calculate areas and determine visiblity
 
-      sortedFaces(1) = 1
-
       do n=1,nFaces
          areas(n) = 0.5*norm2(cross_product(vertices(connectivityList(n,2),:) - vertices(connectivityList(n,1),:), &
                                             vertices(connectivityList(n,3),:) - vertices(connectivityList(n,1),:)))
@@ -118,25 +115,10 @@ contains
          if (dot_product(faceNormal(n,:), nsun) > 0)  visibility(n) = 1
          planeIncenter(n,:) = matmul(invMatrix, incenter(n,:) - p0)
          distIncenter(n) = planeIncenter(n,3)
-         !write(*,*) n, distIncenter(n)
-         ! sort
-         if (n > 1) then
-            m = n
-            do while (m > 1 .and. distIncenter(m) > distIncenter(m - 1)) ! note in descending order (>)
-            ! Swap array(m) and array(m - 1)
-            temp = distIncenter(m)
-            distIncenter(m) = distIncenter(m - 1)
-            distIncenter(m - 1) = temp
-            ! Update the corresponding index
-            id_temp = sortedFaces(m)
-            sortedFaces(m) = sortedFaces(m - 1)
-            sortedFaces(m - 1) = id_temp
-            m = m - 1
-            end do
-            ! Update the index for the newly inserted element
-            sortedFaces(m) = n
-         end if
+         sortedFaces(n) = n
       end do
+
+      call stableSortIndicesDescending(distIncenter, sortedFaces, nFaces)
 
       ! open (unit=11,file='sortedFaces_fort.txt',action="write")
       ! do n=1,nFaces
@@ -153,9 +135,6 @@ contains
 
       do n=1,nVertices
          planeVertices(n,:) = matmul(invMatrix, vertices(n,:) - p0)
-         distVertices(n) = planeVertices(n,3)
-         projVertices(n,:) = vertices(n,:) + distVertices(n) * nsun
-         !write(*,*) n, projVertices(n,:)
       end do
 
       locVertices(:,1) = planeVertices(:,1) + abs(minval(planeVertices(:,1)))
@@ -287,6 +266,53 @@ contains
       print '("Time = ",f10.3," seconds.")',finish-start
 
    end subroutine calculateDirectShortwave
+
+
+   subroutine stableSortIndicesDescending(values, indices, nValues)
+      integer, intent(in) :: nValues
+      real, intent(in) :: values(nValues)
+      integer, intent(inout) :: indices(nValues)
+      integer, allocatable :: work(:)
+      integer :: width, left, middle, right, i, j, k
+
+      if (nValues <= 1) return
+      allocate(work(nValues))
+
+      width = 1
+      do while (width < nValues)
+         left = 1
+         do while (left <= nValues)
+            middle = min(left + width - 1, nValues)
+            right = min(left + 2*width - 1, nValues)
+            i = left
+            j = middle + 1
+
+            do k=left,right
+               if (i > middle) then
+                  work(k) = indices(j)
+                  j = j + 1
+               else if (j > right) then
+                  work(k) = indices(i)
+                  i = i + 1
+               else if (values(indices(i)) >= values(indices(j))) then
+                  ! Prefer the left run for equal values to preserve input order.
+                  work(k) = indices(i)
+                  i = i + 1
+               else
+                  work(k) = indices(j)
+                  j = j + 1
+               end if
+            end do
+            indices(left:right) = work(left:right)
+            left = left + 2*width
+         end do
+
+         if (width > nValues/2) exit
+         width = 2*width
+      end do
+
+      deallocate(work)
+   end subroutine stableSortIndicesDescending
 
 
    subroutine writeDirectShortwave(Sdir, nFaces)

--- a/tools/python/tests/test_directshortwave.py
+++ b/tools/python/tests/test_directshortwave.py
@@ -511,11 +511,13 @@ class TestDirectShortwaveVegetation(unittest.TestCase):
             float(sveg_m[0]), float(sveg_f[0]), delta=1.0e-3 * float(sveg_f[0])
         )
 
-    def test_facsec_parallel_is_deterministic_with_vegetation_and_periodicity(self):
+    def _assert_parallel_is_deterministic_with_vegetation_and_periodicity(
+        self, method
+    ):
         sim, mesh = _build_veg_over_ground_block_fixture()
         solver = DirectShortwaveSolver(
             sim,
-            method="facsec",
+            method=method,
             surface_mesh=mesh,
             ray_density=16.0,
             ray_jitter=0.0,
@@ -554,6 +556,16 @@ class TestDirectShortwaveVegetation(unittest.TestCase):
             self.assertEqual(one_thread[2][key], multi_thread[2][key])
         self.assertAlmostEqual(
             one_thread[2]["veg"], multi_thread[2]["veg"], delta=1.0e-12
+        )
+
+    def test_facsec_parallel_is_deterministic_with_vegetation_and_periodicity(self):
+        self._assert_parallel_is_deterministic_with_vegetation_and_periodicity(
+            "facsec"
+        )
+
+    def test_moller_parallel_is_deterministic_with_vegetation_and_periodicity(self):
+        self._assert_parallel_is_deterministic_with_vegetation_and_periodicity(
+            "moller"
         )
 
 if __name__ == "__main__":

--- a/tools/python/tests/test_directshortwave.py
+++ b/tools/python/tests/test_directshortwave.py
@@ -20,6 +20,8 @@ if not RUN_SLOW_TESTS:
         "slow numba direct-shortwave tests; set UDALES_RUN_SLOW_TESTS=1 to run"
     )
 
+import numba as nb
+
 from udgeom import UDGeom
 from udprep.directshortwave import DirectShortwaveSolver
 
@@ -507,6 +509,51 @@ class TestDirectShortwaveVegetation(unittest.TestCase):
         self.assertAlmostEqual(bud_m["fac"], bud_f["fac"], delta=1.0e-3 * bud_f["fac"])
         self.assertAlmostEqual(
             float(sveg_m[0]), float(sveg_f[0]), delta=1.0e-3 * float(sveg_f[0])
+        )
+
+    def test_facsec_parallel_is_deterministic_with_vegetation_and_periodicity(self):
+        sim, mesh = _build_veg_over_ground_block_fixture()
+        solver = DirectShortwaveSolver(
+            sim,
+            method="facsec",
+            surface_mesh=mesh,
+            ray_density=16.0,
+            ray_jitter=0.0,
+            veg_data=self._veg_data(0, 0, 1),
+        )
+
+        original_threads = nb.get_num_threads()
+        results = {}
+        try:
+            for threads in sorted({1, min(2, original_threads)}):
+                nb.set_num_threads(threads)
+                first = solver.compute(
+                    nsun=self.nsun_vertical,
+                    irradiance=self.IRRADIANCE,
+                    periodic_xy=True,
+                )
+                second = solver.compute(
+                    nsun=self.nsun_vertical,
+                    irradiance=self.IRRADIANCE,
+                    periodic_xy=True,
+                )
+                self.assertTrue(np.array_equal(first[0], second[0]))
+                self.assertTrue(np.array_equal(first[1], second[1]))
+                self.assertEqual(first[2], second[2])
+                results[threads] = first
+        finally:
+            nb.set_num_threads(original_threads)
+
+        one_thread = results[1]
+        multi_thread = results[max(results)]
+        self.assertTrue(np.array_equal(one_thread[0], multi_thread[0]))
+        np.testing.assert_allclose(
+            one_thread[1], multi_thread[1], rtol=1.0e-14, atol=1.0e-14
+        )
+        for key in ("in", "sol", "out", "fac", "rays"):
+            self.assertEqual(one_thread[2][key], multi_thread[2][key])
+        self.assertAlmostEqual(
+            one_thread[2]["veg"], multi_thread[2]["veg"], delta=1.0e-12
         )
 
 if __name__ == "__main__":

--- a/tools/python/tests/test_harmonie_radiation.py
+++ b/tools/python/tests/test_harmonie_radiation.py
@@ -333,6 +333,106 @@ class TestShortwaveTiming(unittest.TestCase):
         self.assertEqual(float(rows[0]["direct_wall_seconds"]), 0.1)
         self.assertGreaterEqual(float(rows[1]["net_wall_seconds"]), 0.0)
 
+    def test_facet_checkpoints_resume_without_recomputation(self):
+        class FakeRadiation:
+            lEB = False
+            maxD = 96.0
+            calls = 0
+
+            @staticmethod
+            def _shortwave_method():
+                return "scanline_f2py", 0.5
+
+            def _compute_knet(self, *_args, timing=None, **_kwargs):
+                self.calls += 1
+                return np.array([10.0, 20.0]), np.array([8.0, 16.0]), None
+
+        radiation = FakeRadiation()
+        sim = types.SimpleNamespace(
+            geom=types.SimpleNamespace(
+                stl=types.SimpleNamespace(
+                    face_normals=np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])
+                )
+            ),
+            assign_prop_to_fac=lambda _name: np.array([0.2, 0.2]),
+        )
+        prep = types.SimpleNamespace(sim=sim, radiation=radiation)
+        atmosphere = ShortwaveAtmosphere(
+            times=np.array([0.0, 10.0]),
+            ghi=np.array([450.0, 0.0]),
+            dni=np.array([500.0, 0.0]),
+            dsky=np.array([100.0, 0.0]),
+            zenith=np.array([45.0, 100.0]),
+            azimuth_local=np.array([180.0, 200.0]),
+        )
+
+        with TemporaryDirectory() as tmp:
+            checkpoint_dir = Path(tmp) / "checkpoints"
+            first = map_atmosphere_to_facets(
+                prep,
+                atmosphere,
+                verbose=False,
+                checkpoint_dir=checkpoint_dir,
+            )
+            self.assertEqual(radiation.calls, 1)
+            self.assertEqual(len(list(checkpoint_dir.glob("step_*.npz"))), 2)
+
+            second = map_atmosphere_to_facets(
+                prep,
+                atmosphere,
+                verbose=False,
+                checkpoint_dir=checkpoint_dir,
+                resume=True,
+            )
+
+        self.assertEqual(radiation.calls, 1)
+        np.testing.assert_array_equal(second[0], first[0])
+        np.testing.assert_array_equal(second[1], first[1])
+
+    @unittest.skipUnless(
+        "fork" in __import__("multiprocessing").get_all_start_methods(),
+        "parallel facet mapping requires multiprocessing fork support",
+    )
+    def test_parallel_facet_mapping_matches_serial(self):
+        class FakeRadiation:
+            lEB = False
+            maxD = 96.0
+
+            @staticmethod
+            def _shortwave_method():
+                return "scanline_f2py", 0.5
+
+            @staticmethod
+            def _compute_knet(*_args, timing=None, **_kwargs):
+                return np.array([10.0, 20.0]), np.array([8.0, 16.0]), None
+
+        sim = types.SimpleNamespace(
+            geom=types.SimpleNamespace(
+                stl=types.SimpleNamespace(
+                    face_normals=np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])
+                )
+            ),
+            assign_prop_to_fac=lambda _name: np.array([0.2, 0.2]),
+        )
+        prep = types.SimpleNamespace(sim=sim, radiation=FakeRadiation())
+        atmosphere = ShortwaveAtmosphere(
+            times=np.array([0.0, 10.0, 20.0]),
+            ghi=np.array([450.0, 50.0, 0.0]),
+            dni=np.array([500.0, 0.0, 0.0]),
+            dsky=np.array([100.0, 50.0, 0.0]),
+            zenith=np.array([45.0, 95.0, 100.0]),
+            azimuth_local=np.array([180.0, 190.0, 200.0]),
+        )
+
+        serial = map_atmosphere_to_facets(prep, atmosphere, verbose=False)
+        parallel = map_atmosphere_to_facets(
+            prep, atmosphere, verbose=False, workers=2
+        )
+
+        np.testing.assert_array_equal(parallel[0], serial[0])
+        np.testing.assert_array_equal(parallel[1], serial[1])
+        self.assertIsNone(parallel[2])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/python/tests/test_harmonie_radiation.py
+++ b/tools/python/tests/test_harmonie_radiation.py
@@ -1,7 +1,9 @@
 """Tests for HARMONIE radiation conversion helpers."""
 
 import csv
+from contextlib import redirect_stdout
 from datetime import datetime
+import io
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -226,6 +228,94 @@ class TestShortwaveWriters(unittest.TestCase):
 
 
 class TestShortwaveTiming(unittest.TestCase):
+    @staticmethod
+    def _nighttime_mapping_fixture():
+        class FakeRadiation:
+            lEB = False
+            maxD = 96.0
+            year, month, day = 2023, 8, 20
+            hour, minute, second = 18, 0, 0
+            timezone = 0.0
+
+            @staticmethod
+            def _shortwave_method():
+                return "scanline_f2py", 0.5
+
+        sim = types.SimpleNamespace(
+            geom=types.SimpleNamespace(
+                stl=types.SimpleNamespace(
+                    face_normals=np.array([[0.0, 0.0, 1.0]])
+                )
+            ),
+            assign_prop_to_fac=lambda _name: np.array([0.2]),
+        )
+        prep = types.SimpleNamespace(sim=sim, radiation=FakeRadiation())
+        atmosphere = ShortwaveAtmosphere(
+            times=np.array([0.0]),
+            ghi=np.array([0.0]),
+            dni=np.array([0.0]),
+            dsky=np.array([0.0]),
+            zenith=np.array([100.0]),
+            azimuth_local=np.array([180.0]),
+        )
+        return prep, atmosphere
+
+    def test_progress_detail_follows_timing_and_quiet_controls(self):
+        prep, atmosphere = self._nighttime_mapping_fixture()
+
+        concise_stream = io.StringIO()
+        with redirect_stdout(concise_stream):
+            map_atmosphere_to_facets(prep, atmosphere, verbose=True)
+        concise = concise_stream.getvalue()
+        self.assertIn("[start   1/1]", concise)
+        self.assertIn("[done   1/1] mode=night", concise)
+        self.assertIn("wall=", concise)
+        self.assertNotIn("GHI=", concise)
+        self.assertNotIn("cpu=", concise)
+        self.assertNotIn("peak_rss=", concise)
+        self.assertNotIn("pid=", concise)
+
+        with TemporaryDirectory() as tmp:
+            detailed_recorder = ShortwaveTimingRecorder(
+                Path(tmp) / "detailed", metadata={}, overwrite=False
+            )
+            detailed_stream = io.StringIO()
+            with redirect_stdout(detailed_stream):
+                map_atmosphere_to_facets(
+                    prep,
+                    atmosphere,
+                    verbose=True,
+                    timing=detailed_recorder,
+                )
+            detailed_recorder.finish(
+                status="completed", total=TimingSample(1.0, 1.0, 10.0)
+            )
+            detailed = detailed_stream.getvalue()
+            self.assertIn("GHI=", detailed)
+            self.assertIn("cpu=", detailed)
+            self.assertIn("peak_rss=", detailed)
+            self.assertIn("pid=", detailed)
+
+            quiet_recorder = ShortwaveTimingRecorder(
+                Path(tmp) / "quiet", metadata={}, overwrite=False
+            )
+            quiet_stream = io.StringIO()
+            with redirect_stdout(quiet_stream):
+                map_atmosphere_to_facets(
+                    prep,
+                    atmosphere,
+                    verbose=False,
+                    timing=quiet_recorder,
+                )
+            quiet_recorder.finish(
+                status="completed", total=TimingSample(1.0, 1.0, 10.0)
+            )
+            self.assertEqual(quiet_stream.getvalue(), "")
+            with (Path(tmp) / "quiet.timestamps.csv").open(
+                "r", encoding="ascii", newline=""
+            ) as handle:
+                self.assertEqual(len(list(csv.DictReader(handle))), 1)
+
     def test_recorder_flushes_timestamp_csv_and_summary(self):
         with TemporaryDirectory() as tmp:
             prefix = Path(tmp) / "baseline"

--- a/tools/python/tests/test_harmonie_radiation.py
+++ b/tools/python/tests/test_harmonie_radiation.py
@@ -1,6 +1,8 @@
 """Tests for HARMONIE radiation conversion helpers."""
 
+import csv
 from datetime import datetime
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import types
@@ -17,12 +19,14 @@ from udprep.harmonie_radiation import (
     format_forecast_offset,
     generate_timedepsw_from_harmonie,
     interpolate_flux_to_times,
+    map_atmosphere_to_facets,
     make_longwave_times,
     make_model_times,
     split_global_horizontal_erbs,
     write_netsw,
     write_timedeplw,
 )
+from udprep.radiation_timing import ShortwaveTimingRecorder, TimingSample
 
 
 class FakeAccumulationReader:
@@ -207,12 +211,127 @@ class TestShortwaveWriters(unittest.TestCase):
                     nwp_root=Path(tmp),
                     write_sdir_nc=False,
                     verbose=False,
+                    timing_prefix=case_dir / "benchmark",
                 )
 
             self.assertEqual(result.netsw_path, case_dir / "netsw.inp.300")
             np.testing.assert_allclose(
                 np.loadtxt(result.netsw_path, skiprows=1), knet[:, 0]
             )
+            summary = json.loads(
+                (case_dir / "benchmark.summary.json").read_text(encoding="ascii")
+            )
+            self.assertEqual(summary["status"], "completed")
+            self.assertIn("total_wall_seconds", summary)
+
+
+class TestShortwaveTiming(unittest.TestCase):
+    def test_recorder_flushes_timestamp_csv_and_summary(self):
+        with TemporaryDirectory() as tmp:
+            prefix = Path(tmp) / "baseline"
+            recorder = ShortwaveTimingRecorder(
+                prefix,
+                metadata={"experiment": "302"},
+                overwrite=False,
+            )
+            recorder.record_stage("load", TimingSample(1.0, 0.5, 12.0))
+            recorder.record_timestamp(
+                {
+                    "index": 1,
+                    "total": 2,
+                    "model_time_seconds": 0.0,
+                    "mode": "night",
+                    "step_wall_seconds": 0.01,
+                    "step_cpu_seconds": 0.01,
+                }
+            )
+
+            with Path(f"{prefix}.timestamps.csv").open(
+                "r", encoding="ascii", newline=""
+            ) as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["mode"], "night")
+
+            running = json.loads(
+                Path(f"{prefix}.summary.json").read_text(encoding="ascii")
+            )
+            self.assertEqual(running["status"], "running")
+            self.assertEqual(running["timestamps_completed"], 1)
+
+            recorder.finish(
+                status="completed",
+                total=TimingSample(2.0, 1.0, 13.0),
+            )
+            completed = json.loads(
+                Path(f"{prefix}.summary.json").read_text(encoding="ascii")
+            )
+            self.assertEqual(completed["status"], "completed")
+            self.assertEqual(completed["peak_rss_mib"], 13.0)
+
+    def test_facet_mapping_timing_preserves_results_and_classifies_steps(self):
+        class FakeRadiation:
+            lEB = False
+            maxD = 96.0
+            year, month, day = 2023, 8, 20
+            hour, minute, second = 18, 0, 0
+            timezone = 0.0
+
+            @staticmethod
+            def _shortwave_method():
+                return "scanline_f2py", 0.5
+
+            @staticmethod
+            def _compute_knet(*_args, timing=None, **_kwargs):
+                if timing is not None:
+                    timing.update(
+                        direct_wall_seconds=0.1,
+                        direct_cpu_seconds=0.1,
+                        net_wall_seconds=0.01,
+                        net_cpu_seconds=0.01,
+                    )
+                return np.array([10.0, 20.0]), np.array([8.0, 16.0]), None
+
+        sim = types.SimpleNamespace(
+            geom=types.SimpleNamespace(
+                stl=types.SimpleNamespace(
+                    face_normals=np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])
+                )
+            ),
+            assign_prop_to_fac=lambda _name: np.array([0.2, 0.2]),
+        )
+        prep = types.SimpleNamespace(sim=sim, radiation=FakeRadiation())
+        atmosphere = ShortwaveAtmosphere(
+            times=np.array([0.0, 10.0, 20.0]),
+            ghi=np.array([450.0, 50.0, 0.0]),
+            dni=np.array([500.0, 0.0, 0.0]),
+            dsky=np.array([100.0, 50.0, 0.0]),
+            zenith=np.array([45.0, 95.0, 100.0]),
+            azimuth_local=np.array([180.0, 190.0, 200.0]),
+        )
+
+        untimed = map_atmosphere_to_facets(prep, atmosphere, verbose=False)
+        with TemporaryDirectory() as tmp:
+            prefix = Path(tmp) / "mapping"
+            recorder = ShortwaveTimingRecorder(prefix, metadata={}, overwrite=False)
+            timed = map_atmosphere_to_facets(
+                prep, atmosphere, verbose=False, timing=recorder
+            )
+            recorder.finish(
+                status="completed",
+                total=TimingSample(1.0, 1.0, 10.0),
+            )
+            with Path(f"{prefix}.timestamps.csv").open(
+                "r", encoding="ascii", newline=""
+            ) as handle:
+                rows = list(csv.DictReader(handle))
+
+        np.testing.assert_array_equal(timed[0], untimed[0])
+        np.testing.assert_array_equal(timed[1], untimed[1])
+        self.assertIsNone(timed[2])
+        self.assertEqual([row["mode"] for row in rows], ["direct", "diffuse", "night"])
+        self.assertEqual(float(rows[0]["direct_wall_seconds"]), 0.1)
+        self.assertGreaterEqual(float(rows[1]["net_wall_seconds"]), 0.0)
 
 
 if __name__ == "__main__":

--- a/tools/python/tests/test_udprep_core.py
+++ b/tools/python/tests/test_udprep_core.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import sys
 import types
 import unittest
@@ -1052,6 +1053,23 @@ class TestRadiationSection(unittest.TestCase):
         self.assertEqual(knet.shape, (4, 3))
         section._write_sdir_nc.assert_called_once()
         section.write_timedepsveg.assert_not_called()
+
+    def test_timedep_progress_is_indexed_and_backend_agnostic(self):
+        stream = io.StringIO()
+        with TemporaryDirectory() as tmp, contextlib.redirect_stdout(stream):
+            self._run_timedep(
+                tmp, nfcts=4, ltrees=False, s_veg_value=np.zeros(0, dtype=float)
+            )
+
+        lines = [line for line in stream.getvalue().splitlines() if line]
+        self.assertEqual(len(lines), 3)
+        self.assertRegex(
+            lines[0],
+            r"^\[shortwave\s+1/3\] t=\s+0\.0s mode=direct "
+            r"method=moller wall=\d+\.\d{3}s$",
+        )
+        self.assertIn("[shortwave   3/3]", lines[-1])
+        self.assertNotIn("Time =", stream.getvalue())
 
     def test_timedep_veg_stores_nveg_rows(self):
         nfcts, nveg = 4, 7

--- a/tools/python/tests/test_udprep_core.py
+++ b/tools/python/tests/test_udprep_core.py
@@ -973,6 +973,7 @@ class TestRadiationSection(unittest.TestCase):
         section.calc_direct_sw = fake_calc_direct_sw
         section.calc_reflections_sw = fake_calc_reflections_sw
 
+        timing = {}
         sdir, knet, s_veg = section._compute_knet(
             np.array([0.0, 0.0, 1.0]),
             800.0,
@@ -984,6 +985,7 @@ class TestRadiationSection(unittest.TestCase):
             object(),
             np.ones(3),
             None,
+            timing=timing,
         )
 
         expected = np.round(full_sdir, 2)
@@ -992,6 +994,10 @@ class TestRadiationSection(unittest.TestCase):
         np.testing.assert_allclose(knet, expected + 1.0)
         self.assertIsInstance(s_veg, np.ndarray)
         self.assertEqual(s_veg.size, 0)
+        self.assertGreaterEqual(timing["direct_wall_seconds"], 0.0)
+        self.assertGreaterEqual(timing["direct_cpu_seconds"], 0.0)
+        self.assertGreaterEqual(timing["net_wall_seconds"], 0.0)
+        self.assertGreaterEqual(timing["net_cpu_seconds"], 0.0)
 
     # ------------------------------------------------------------------
     # Item 1 (P1): run_short_wave_timedep vegetation array-shape contract

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -597,8 +597,6 @@ if nb is not None:
         cell_offsets: np.ndarray,
         cell_facets: np.ndarray,
         triangles: np.ndarray,
-        facet_hit_energy: np.ndarray,
-        solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
         itot: int,
@@ -609,7 +607,7 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-    ) -> float:
+    ) -> Tuple[float, int, int, int, float, int, float]:
         x, y, z = origin
 
         i, j, k = _point_to_cell_numba(
@@ -626,7 +624,7 @@ if nb is not None:
             allow_outside_xy,
         )
         if i < 0:
-            return 0.0
+            return 0.0, -1, -1, -1, 0.0, -1, 0.0
 
         dir_x, dir_y, dir_z = direction
         step_x = 0 if dir_x == 0.0 else (1 if dir_x > 0.0 else -1)
@@ -745,14 +743,12 @@ if nb is not None:
                 # sharing this cell is not double-counted (the facsec kernel
                 # attenuates before the hit for the same reason).
                 if base_inside:
-                    if hit_fid_cell >= 0:
-                        facet_hit_energy[hit_fid_cell] += r_in * ray_area * irradiance
-                    solid_hit_energy[ii, jj, k] += r_in * ray_area * irradiance
-                    return 0.0
-                return r_in * ray_area * irradiance
+                    hit_energy = r_in * ray_area * irradiance
+                    return 0.0, ii, jj, k, hit_energy, hit_fid_cell, hit_energy
+                return r_in * ray_area * irradiance, -1, -1, -1, 0.0, -1, 0.0
 
             if t_next > max_ray_length:
-                return r_in * ray_area * irradiance
+                return r_in * ray_area * irradiance, -1, -1, -1, 0.0, -1, 0.0
 
             prev_i, prev_j, prev_k = last_i, last_j, last_k
             if base_inside:
@@ -773,9 +769,9 @@ if nb is not None:
             t = t_next
 
         if dir_z < 0.0 and k < 0 and last_i >= 0:
-            solid_hit_energy[last_i, last_j, last_k] += r_in * ray_area * irradiance
-            return 0.0
-        return r_in * ray_area * irradiance
+            hit_energy = r_in * ray_area * irradiance
+            return 0.0, last_i, last_j, last_k, hit_energy, -1, 0.0
+        return r_in * ray_area * irradiance, -1, -1, -1, 0.0, -1, 0.0
 
     @nb.njit(cache=True)
     def _trace_ray_segments_numba(
@@ -885,7 +881,7 @@ if nb is not None:
             t = t_next
         return buf, idx
 
-    @nb.njit(cache=True)
+    @nb.njit(cache=True, parallel=True)
     def _cast_rays_numba(
         u_vals: np.ndarray,
         v_vals: np.ndarray,
@@ -909,9 +905,17 @@ if nb is not None:
         cell_offsets: np.ndarray,
         cell_facets: np.ndarray,
         triangles: np.ndarray,
-        facet_hit_energy: np.ndarray,
-        solid_hit_energy: np.ndarray,
-        veg_absorb: np.ndarray,
+        ray_start: int,
+        ray_count: int,
+        hit_i: np.ndarray,
+        hit_j: np.ndarray,
+        hit_k: np.ndarray,
+        hit_energy: np.ndarray,
+        facet_id: np.ndarray,
+        facet_energy: np.ndarray,
+        ray_valid: np.ndarray,
+        ray_out: np.ndarray,
+        veg_absorb_thread: np.ndarray,
         ray_area: float,
         itot: int,
         jtot: int,
@@ -921,59 +925,70 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-        bud_in: np.ndarray,
-        bud_out: np.ndarray,
     ) -> None:
-        nu = u_vals.shape[0]
         nv = v_vals.shape[0]
-        idx = 0
-        for iu in range(nu):
-            u = u_vals[iu]
-            for iv in range(nv):
-                v = v_vals[iv]
-                if use_jitter:
-                    u_use = u + jitter_u[idx]
-                    v_use = v + jitter_v[idx]
-                else:
-                    u_use = u
-                    v_use = v
-                idx += 1
-                origin = p0 + u1 * u_use + u2 * v_use
-                t0, t1 = _ray_box_intersection_numba(origin, direction, bounds_min, bounds_max)
-                if t1 < t0:
-                    continue
-                if t1 < 0.0:
-                    continue
-                bud_in[0] += irradiance * ray_area
-                entry = t0 if t0 > 0.0 else 0.0
-                start = origin + direction * (entry + 1.0e-6)
-                bud_out[0] += _trace_ray_moller_numba(
-                    start,
-                    direction,
-                    dx,
-                    dy,
-                    z_edges,
-                    z_max,
-                    lad_3d,
-                    dec_3d,
-                    veg_index,
-                    cell_has_facets,
-                    cell_offsets,
-                    cell_facets,
-                    triangles,
-                    facet_hit_energy,
-                    solid_hit_energy,
-                    veg_absorb,
-                    ray_area,
-                    itot,
-                    jtot,
-                    ktot,
-                    dz,
-                    irradiance,
-                    periodic_xy,
-                    max_ray_length,
-                    allow_outside_xy,
-                )
+        for local_idx in nb.prange(ray_count):
+            idx = ray_start + local_idx
+            iu = idx // nv
+            iv = idx - iu * nv
+            u_use = u_vals[iu]
+            v_use = v_vals[iv]
+            if use_jitter:
+                u_use += jitter_u[idx]
+                v_use += jitter_v[idx]
+
+            hit_i[local_idx] = -1
+            hit_j[local_idx] = -1
+            hit_k[local_idx] = -1
+            hit_energy[local_idx] = 0.0
+            facet_id[local_idx] = -1
+            facet_energy[local_idx] = 0.0
+            ray_valid[local_idx] = False
+            ray_out[local_idx] = 0.0
+
+            origin = p0 + u1 * u_use + u2 * v_use
+            t0, t1 = _ray_box_intersection_numba(
+                origin, direction, bounds_min, bounds_max
+            )
+            if t1 < t0 or t1 < 0.0:
+                continue
+
+            ray_valid[local_idx] = True
+            entry = t0 if t0 > 0.0 else 0.0
+            start = origin + direction * (entry + 1.0e-6)
+            thread_id = nb.get_thread_id()
+            out_energy, hi, hj, hk, he, fid, fe = _trace_ray_moller_numba(
+                start,
+                direction,
+                dx,
+                dy,
+                z_edges,
+                z_max,
+                lad_3d,
+                dec_3d,
+                veg_index,
+                cell_has_facets,
+                cell_offsets,
+                cell_facets,
+                triangles,
+                veg_absorb_thread[thread_id],
+                ray_area,
+                itot,
+                jtot,
+                ktot,
+                dz,
+                irradiance,
+                periodic_xy,
+                max_ray_length,
+                allow_outside_xy,
+            )
+            ray_out[local_idx] = out_energy
+            hit_i[local_idx] = hi
+            hit_j[local_idx] = hj
+            hit_k[local_idx] = hk
+            hit_energy[local_idx] = he
+            facet_id[local_idx] = fid
+            facet_energy[local_idx] = fe
 
     @nb.njit(cache=True, parallel=True)
     def _cast_rays_facsec_numba(
@@ -1429,53 +1444,102 @@ class DirectShortwaveSolver:
             jitter_v = np.zeros(bud["rays"], dtype=float)
 
         solid_hit_energy = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
-        veg_absorb = np.zeros(len(self.veg.points), dtype=float)
         facet_hit_energy = np.zeros(self.nfaces, dtype=float)
 
-        bud_in = np.zeros(1, dtype=float)
-        bud_out = np.zeros(1, dtype=float)
-
-        # Cast all rays with triangle intersection tests; accumulate energy in arrays.
-        _cast_rays_numba(
-            u_vals,
-            v_vals,
-            jitter_u,
-            jitter_v,
-            use_jitter,
-            p0,
-            u1,
-            u2,
-            direction,
-            *self._compute_bounds(direction),
-            self.sim.dx,
-            self.sim.dy,
-            self.z_edges,
-            self.z_max,
-            self.lad_3d,
-            self.dec_3d,
-            self.veg_index,
-            self.cell_has_facets,
-            self.cell_offsets,
-            self.cell_facets,
-            self.triangles,
-            facet_hit_energy,
-            solid_hit_energy,
-            veg_absorb,
-            ray_area,
-            self.sim.itot,
-            self.sim.jtot,
-            self.ktot,
-            self.dz,
-            irradiance,
-            periodic_xy,
-            10.0 * max(self.sim.xlen, self.sim.ylen),
-            True,
-            bud_in,
-            bud_out,
+        thread_count = nb.get_num_threads()
+        veg_absorb_thread = np.zeros(
+            (thread_count, len(self.veg.points)), dtype=float
         )
+        block_capacity = max(1, min(bud["rays"], _PARALLEL_RAY_BLOCK_SIZE))
+        hit_i = np.empty(block_capacity, dtype=np.int32)
+        hit_j = np.empty(block_capacity, dtype=np.int32)
+        hit_k = np.empty(block_capacity, dtype=np.int32)
+        hit_energy = np.empty(block_capacity, dtype=float)
+        facet_id = np.empty(block_capacity, dtype=np.int32)
+        facet_energy = np.empty(block_capacity, dtype=float)
+        ray_valid = np.empty(block_capacity, dtype=bool)
+        ray_out = np.empty(block_capacity, dtype=float)
 
-        bud["in"] = float(bud_in[0])
-        bud["out"] = float(bud_out[0])
+        bounds_min, bounds_max = self._compute_bounds(direction)
+        ray_input_energy = irradiance * ray_area
+        budget_in = 0.0
+        budget_out = 0.0
+        # Bound per-ray scratch while preserving ray-order scattering and budgets.
+        for ray_start in range(0, bud["rays"], block_capacity):
+            ray_count = min(block_capacity, bud["rays"] - ray_start)
+            _cast_rays_numba(
+                u_vals,
+                v_vals,
+                jitter_u,
+                jitter_v,
+                use_jitter,
+                p0,
+                u1,
+                u2,
+                direction,
+                bounds_min,
+                bounds_max,
+                self.sim.dx,
+                self.sim.dy,
+                self.z_edges,
+                self.z_max,
+                self.lad_3d,
+                self.dec_3d,
+                self.veg_index,
+                self.cell_has_facets,
+                self.cell_offsets,
+                self.cell_facets,
+                self.triangles,
+                ray_start,
+                ray_count,
+                hit_i,
+                hit_j,
+                hit_k,
+                hit_energy,
+                facet_id,
+                facet_energy,
+                ray_valid,
+                ray_out,
+                veg_absorb_thread,
+                ray_area,
+                self.sim.itot,
+                self.sim.jtot,
+                self.ktot,
+                self.dz,
+                irradiance,
+                periodic_xy,
+                10.0 * max(self.sim.xlen, self.sim.ylen),
+                True,
+            )
+
+            solid_hit = hit_i[:ray_count] >= 0
+            np.add.at(
+                solid_hit_energy,
+                (
+                    hit_i[:ray_count][solid_hit],
+                    hit_j[:ray_count][solid_hit],
+                    hit_k[:ray_count][solid_hit],
+                ),
+                hit_energy[:ray_count][solid_hit],
+            )
+            facet_hit = facet_id[:ray_count] >= 0
+            np.add.at(
+                facet_hit_energy,
+                facet_id[:ray_count][facet_hit],
+                facet_energy[:ray_count][facet_hit],
+            )
+            budget_in, budget_out = _reduce_ray_budget_numba(
+                ray_valid,
+                ray_out,
+                ray_count,
+                ray_input_energy,
+                budget_in,
+                budget_out,
+            )
+
+        veg_absorb = np.sum(veg_absorb_thread, axis=0)
+        bud["in"] = float(budget_in)
+        bud["out"] = float(budget_out)
 
         cos_inc_all = np.dot(self.face_normals, nsun_unit)
         cos_inc_all = np.where(cos_inc_all > 0.0, cos_inc_all, 0.0)

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -23,6 +23,11 @@ except ImportError:  # pragma: no cover - runtime dependent
     nb = None
 
 from exceptions import DependencyError, RadiationError
+
+
+_PARALLEL_RAY_BLOCK_SIZE = 1_000_000
+
+
 @dataclass
 class VegData:
     points: np.ndarray  # (n, 3) 0-based (i, j, k)
@@ -404,7 +409,6 @@ if nb is not None:
         veg_index: np.ndarray,
         solid: np.ndarray,
         has_solid: bool,
-        solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
         itot: int,
@@ -415,7 +419,7 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-    ) -> float:
+    ) -> Tuple[float, int, int, int, float]:
         i, j, k = _point_to_cell_numba(
             x,
             y,
@@ -430,7 +434,7 @@ if nb is not None:
             allow_outside_xy,
         )
         if i < 0:
-            return 0.0
+            return 0.0, -1, -1, -1, 0.0
 
         step_x = 0 if dir_x == 0.0 else (1 if dir_x > 0.0 else -1)
         step_y = 0 if dir_y == 0.0 else (1 if dir_y > 0.0 else -1)
@@ -485,18 +489,18 @@ if nb is not None:
                 jj = j % jtot
                 if has_solid and solid[ii, jj, k]:
                     if inside and last_i >= 0:
-                        solid_hit_energy[last_i, last_j, last_k] += r_in * ray_area * irradiance
-                        return 0.0
-                    return r_in * ray_area * irradiance
+                        hit_energy = r_in * ray_area * irradiance
+                        return 0.0, last_i, last_j, last_k, hit_energy
+                    return r_in * ray_area * irradiance, -1, -1, -1, 0.0
             else:
                 if inside:
                     ii = i
                     jj = j
                     if has_solid and solid[ii, jj, k]:
                         if last_i >= 0:
-                            solid_hit_energy[last_i, last_j, last_k] += r_in * ray_area * irradiance
-                            return 0.0
-                        return r_in * ray_area * irradiance
+                            hit_energy = r_in * ray_area * irradiance
+                            return 0.0, last_i, last_j, last_k, hit_energy
+                        return r_in * ray_area * irradiance, -1, -1, -1, 0.0
                 else:
                     ii = i
                     jj = j
@@ -523,7 +527,7 @@ if nb is not None:
                     r_in = r_out
 
             if t_next > max_ray_length:
-                return r_in * ray_area * irradiance
+                return r_in * ray_area * irradiance, -1, -1, -1, 0.0
 
             prev_i, prev_j, prev_k = last_i, last_j, last_k
             if inside:
@@ -544,9 +548,9 @@ if nb is not None:
             t = t_next
 
         if dir_z < 0.0 and k < 0 and last_i >= 0:
-            solid_hit_energy[last_i, last_j, last_k] += r_in * ray_area * irradiance
-            return 0.0
-        return r_in * ray_area * irradiance
+            hit_energy = r_in * ray_area * irradiance
+            return 0.0, last_i, last_j, last_k, hit_energy
+        return r_in * ray_area * irradiance, -1, -1, -1, 0.0
 
     @nb.njit(cache=True)
     def _trace_ray_moller_numba(
@@ -957,7 +961,7 @@ if nb is not None:
                     debug_test_count,
                 )
 
-    @nb.njit(cache=True)
+    @nb.njit(cache=True, parallel=True)
     def _cast_rays_facsec_numba(
         u_vals: np.ndarray,
         v_vals: np.ndarray,
@@ -979,8 +983,15 @@ if nb is not None:
         veg_index: np.ndarray,
         solid: np.ndarray,
         has_solid: bool,
-        solid_hit_energy: np.ndarray,
-        veg_absorb: np.ndarray,
+        ray_start: int,
+        ray_count: int,
+        hit_i: np.ndarray,
+        hit_j: np.ndarray,
+        hit_k: np.ndarray,
+        hit_energy: np.ndarray,
+        ray_valid: np.ndarray,
+        ray_out: np.ndarray,
+        veg_absorb_thread: np.ndarray,
         ray_area: float,
         itot: int,
         jtot: int,
@@ -990,10 +1001,7 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-        bud_in: np.ndarray,
-        bud_out: np.ndarray,
     ) -> None:
-        nu = u_vals.shape[0]
         nv = v_vals.shape[0]
         p0x, p0y, p0z = p0
         u1x, u1y, u1z = u1
@@ -1001,72 +1009,96 @@ if nb is not None:
         dir_x, dir_y, dir_z = direction
         xmin, ymin, zmin = bounds_min
         xmax, ymax, zmax = bounds_max
-        for iu in range(nu):
-            u = u_vals[iu]
-            for iv in range(nv):
-                idx = iu * nv + iv
-                v = v_vals[iv]
-                if use_jitter:
-                    u_use = u + jitter_u[idx]
-                    v_use = v + jitter_v[idx]
-                else:
-                    u_use = u
-                    v_use = v
-                ox = p0x + u1x * u_use + u2x * v_use
-                oy = p0y + u1y * u_use + u2y * v_use
-                oz = p0z + u1z * u_use + u2z * v_use
-                t0, t1 = _ray_box_intersection_scalar_numba(
-                    ox,
-                    oy,
-                    oz,
-                    dir_x,
-                    dir_y,
-                    dir_z,
-                    xmin,
-                    ymin,
-                    zmin,
-                    xmax,
-                    ymax,
-                    zmax,
-                )
-                if t1 < t0:
-                    continue
-                if t1 < 0.0:
-                    continue
-                bud_in[0] += irradiance * ray_area
-                entry = t0 if t0 > 0.0 else 0.0
-                start_offset = entry + 1.0e-6
-                sx = ox + dir_x * start_offset
-                sy = oy + dir_y * start_offset
-                sz = oz + dir_z * start_offset
-                bud_out[0] += _trace_ray_facsec_numba(
-                    sx,
-                    sy,
-                    sz,
-                    dir_x,
-                    dir_y,
-                    dir_z,
-                    dx,
-                    dy,
-                    z_edges,
-                    z_max,
-                    lad_3d,
-                    dec_3d,
-                    veg_index,
-                    solid,
-                    has_solid,
-                    solid_hit_energy,
-                    veg_absorb,
-                    ray_area,
-                    itot,
-                    jtot,
-                    ktot,
-                    dz,
-                    irradiance,
-                    periodic_xy,
-                    max_ray_length,
-                    allow_outside_xy,
-                )
+        for local_idx in nb.prange(ray_count):
+            idx = ray_start + local_idx
+            iu = idx // nv
+            iv = idx - iu * nv
+            u_use = u_vals[iu]
+            v_use = v_vals[iv]
+            if use_jitter:
+                u_use += jitter_u[idx]
+                v_use += jitter_v[idx]
+
+            hit_i[local_idx] = -1
+            hit_j[local_idx] = -1
+            hit_k[local_idx] = -1
+            hit_energy[local_idx] = 0.0
+            ray_valid[local_idx] = False
+            ray_out[local_idx] = 0.0
+
+            ox = p0x + u1x * u_use + u2x * v_use
+            oy = p0y + u1y * u_use + u2y * v_use
+            oz = p0z + u1z * u_use + u2z * v_use
+            t0, t1 = _ray_box_intersection_scalar_numba(
+                ox,
+                oy,
+                oz,
+                dir_x,
+                dir_y,
+                dir_z,
+                xmin,
+                ymin,
+                zmin,
+                xmax,
+                ymax,
+                zmax,
+            )
+            if t1 < t0 or t1 < 0.0:
+                continue
+
+            ray_valid[local_idx] = True
+            start_offset = (t0 if t0 > 0.0 else 0.0) + 1.0e-6
+            sx = ox + dir_x * start_offset
+            sy = oy + dir_y * start_offset
+            sz = oz + dir_z * start_offset
+            thread_id = nb.get_thread_id()
+            out_energy, hi, hj, hk, he = _trace_ray_facsec_numba(
+                sx,
+                sy,
+                sz,
+                dir_x,
+                dir_y,
+                dir_z,
+                dx,
+                dy,
+                z_edges,
+                z_max,
+                lad_3d,
+                dec_3d,
+                veg_index,
+                solid,
+                has_solid,
+                veg_absorb_thread[thread_id],
+                ray_area,
+                itot,
+                jtot,
+                ktot,
+                dz,
+                irradiance,
+                periodic_xy,
+                max_ray_length,
+                allow_outside_xy,
+            )
+            ray_out[local_idx] = out_energy
+            hit_i[local_idx] = hi
+            hit_j[local_idx] = hj
+            hit_k[local_idx] = hk
+            hit_energy[local_idx] = he
+
+    @nb.njit(cache=True)
+    def _reduce_ray_budget_numba(
+        ray_valid: np.ndarray,
+        ray_out: np.ndarray,
+        ray_count: int,
+        ray_input_energy: float,
+        budget_in: float,
+        budget_out: float,
+    ) -> Tuple[float, float]:
+        for idx in range(ray_count):
+            if ray_valid[idx]:
+                budget_in += ray_input_energy
+                budget_out += ray_out[idx]
+        return budget_in, budget_out
 
 
 class DirectShortwaveSolver:
@@ -1491,7 +1523,6 @@ class DirectShortwaveSolver:
         use_jitter = self.ray_jitter > 0.0
 
         solid_hit_energy = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
-        veg_absorb = np.zeros(len(self.veg.points), dtype=float)
 
         bud = {"in": 0.0, "veg": 0.0, "sol": 0.0, "out": 0.0, "fac": 0.0}
         bud["rays"] = int(len(u_vals) * len(v_vals))
@@ -1504,46 +1535,88 @@ class DirectShortwaveSolver:
             jitter_u = np.zeros(bud["rays"], dtype=float)
             jitter_v = np.zeros(bud["rays"], dtype=float)
 
-        bud_in = np.zeros(1, dtype=float)
-        bud_out = np.zeros(1, dtype=float)
-
-        # Trace rays through the solid mask inside numba; energy is accumulated per grid cell.
-        _cast_rays_facsec_numba(
-            u_vals,
-            v_vals,
-            jitter_u,
-            jitter_v,
-            use_jitter,
-            p0,
-            u1,
-            u2,
-            direction,
-            *self._compute_bounds(direction),
-            self.sim.dx,
-            self.sim.dy,
-            self.z_edges,
-            self.z_max,
-            self.lad_3d,
-            self.dec_3d,
-            self.veg_index,
-            self.solid,
-            self.has_solid,
-            solid_hit_energy,
-            veg_absorb,
-            ray_area,
-            self.sim.itot,
-            self.sim.jtot,
-            self.ktot,
-            self.dz,
-            irradiance,
-            periodic_xy,
-            10.0 * max(self.sim.xlen, self.sim.ylen),
-            True,
-            bud_in,
-            bud_out,
+        thread_count = nb.get_num_threads()
+        veg_absorb_thread = np.zeros(
+            (thread_count, len(self.veg.points)), dtype=float
         )
-        bud["in"] = float(bud_in[0])
-        bud["out"] = float(bud_out[0])
+        block_capacity = max(1, min(bud["rays"], _PARALLEL_RAY_BLOCK_SIZE))
+        hit_i = np.empty(block_capacity, dtype=np.int32)
+        hit_j = np.empty(block_capacity, dtype=np.int32)
+        hit_k = np.empty(block_capacity, dtype=np.int32)
+        hit_energy = np.empty(block_capacity, dtype=float)
+        ray_valid = np.empty(block_capacity, dtype=bool)
+        ray_out = np.empty(block_capacity, dtype=float)
+
+        bounds_min, bounds_max = self._compute_bounds(direction)
+        ray_input_energy = irradiance * ray_area
+        budget_in = 0.0
+        budget_out = 0.0
+        # Bound per-ray scratch while preserving ray-order scattering and budgets.
+        for ray_start in range(0, bud["rays"], block_capacity):
+            ray_count = min(block_capacity, bud["rays"] - ray_start)
+            _cast_rays_facsec_numba(
+                u_vals,
+                v_vals,
+                jitter_u,
+                jitter_v,
+                use_jitter,
+                p0,
+                u1,
+                u2,
+                direction,
+                bounds_min,
+                bounds_max,
+                self.sim.dx,
+                self.sim.dy,
+                self.z_edges,
+                self.z_max,
+                self.lad_3d,
+                self.dec_3d,
+                self.veg_index,
+                self.solid,
+                self.has_solid,
+                ray_start,
+                ray_count,
+                hit_i,
+                hit_j,
+                hit_k,
+                hit_energy,
+                ray_valid,
+                ray_out,
+                veg_absorb_thread,
+                ray_area,
+                self.sim.itot,
+                self.sim.jtot,
+                self.ktot,
+                self.dz,
+                irradiance,
+                periodic_xy,
+                10.0 * max(self.sim.xlen, self.sim.ylen),
+                True,
+            )
+
+            hit = hit_i[:ray_count] >= 0
+            np.add.at(
+                solid_hit_energy,
+                (
+                    hit_i[:ray_count][hit],
+                    hit_j[:ray_count][hit],
+                    hit_k[:ray_count][hit],
+                ),
+                hit_energy[:ray_count][hit],
+            )
+            budget_in, budget_out = _reduce_ray_budget_numba(
+                ray_valid,
+                ray_out,
+                ray_count,
+                ray_input_energy,
+                budget_in,
+                budget_out,
+            )
+
+        veg_absorb = np.sum(veg_absorb_thread, axis=0)
+        bud["in"] = float(budget_in)
+        bud["out"] = float(budget_out)
 
         cos_inc_all = np.dot(self.face_normals, nsun_unit)
         cos_inc_all = np.where(cos_inc_all > 0.0, cos_inc_all, 0.0)

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -1125,15 +1125,24 @@ class DirectShortwaveSolver:
             facsec = sim.facsec["c"]
             facsec_locs = facsec["locs"].astype(int)
 
-        self.ktot, self.z_edges, self.z_max, self.dz = _compute_ktot_and_z_edges(
-            sim,
-            self.veg.points if self.veg.points.size else None,
-            mesh=surface_mesh,
-            facsec_locs=facsec_locs,
-        )
-        self.lad_3d, self.dec_3d, self.veg_index = _build_veg_fields(
-            sim, self.veg, self.ktot
-        )
+        if self.method in ("moller", "facsec"):
+            self.ktot, self.z_edges, self.z_max, self.dz = _compute_ktot_and_z_edges(
+                sim,
+                self.veg.points if self.veg.points.size else None,
+                mesh=surface_mesh,
+                facsec_locs=facsec_locs,
+            )
+            self.lad_3d, self.dec_3d, self.veg_index = _build_veg_fields(
+                sim, self.veg, self.ktot
+            )
+        else:
+            self.ktot = 0
+            self.z_edges = np.empty(0, dtype=float)
+            self.z_max = 0.0
+            self.dz = np.empty(0, dtype=float)
+            self.lad_3d = np.empty((0, 0, 0), dtype=float)
+            self.dec_3d = np.empty((0, 0, 0), dtype=float)
+            self.veg_index = np.empty((0, 0, 0), dtype=int)
 
         self.mesh = surface_mesh
         mesh = surface_mesh
@@ -1142,6 +1151,31 @@ class DirectShortwaveSolver:
         self.face_areas = mesh.area_faces
         if hasattr(sim, "facs") and "area" in sim.facs and sim.facs["area"].shape == self.face_areas.shape:
             self.face_areas = sim.facs["area"]
+
+        if self.method in ("scanline_f2py", "scanline_legacy"):
+            self._scanline_faces_1based = np.asfortranarray(
+                np.asarray(mesh.faces, dtype=np.int32) + 1
+            )
+            self._scanline_facet_points = np.asfortranarray(
+                np.asarray(self.sim.geom.face_incenters, dtype=float)
+            )
+            self._scanline_face_normals = np.asfortranarray(
+                np.asarray(mesh.face_normals, dtype=float)
+            )
+            self._scanline_vertices = np.asfortranarray(
+                np.asarray(mesh.vertices, dtype=float)
+            )
+
+        if self.method == "scanline_f2py":
+            self._scanline_facet_points_f2py = np.asfortranarray(
+                self._scanline_facet_points, dtype=np.float32
+            )
+            self._scanline_face_normals_f2py = np.asfortranarray(
+                self._scanline_face_normals, dtype=np.float32
+            )
+            self._scanline_vertices_f2py = np.asfortranarray(
+                self._scanline_vertices, dtype=np.float32
+            )
 
         if self.method == "moller":
             if hasattr(mesh, "triangles"):
@@ -1526,10 +1560,10 @@ class DirectShortwaveSolver:
         inputs = self._build_scanline_inputs(nsun_unit, irradiance, resolution=resolution)
 
         sdir = self._dsmod.calculate_direct_shortwave_f2py(
-            np.asfortranarray(inputs.faces_1based, dtype=np.int32),
-            np.asfortranarray(inputs.facet_points, dtype=np.float32),
-            np.asfortranarray(inputs.face_normals, dtype=np.float32),
-            np.asfortranarray(inputs.vertices, dtype=np.float32),
+            self._scanline_faces_1based,
+            self._scanline_facet_points_f2py,
+            self._scanline_face_normals_f2py,
+            self._scanline_vertices_f2py,
             inputs.nsun,
             inputs.irradiance,
             inputs.resolution,
@@ -1600,17 +1634,16 @@ class DirectShortwaveSolver:
         - vertices are TR.Points
         - info_directShortwave.txt carries nsun, irradiance, and resolution
         """
-        mesh = self.mesh
         if resolution is None:
             cell_min = min(self.sim.dx, self.sim.dy, float(np.min(self.sim.dzt)))
             resolution = 0.25 * cell_min / self.ray_density
         if resolution <= 0.0:
             raise ValueError("resolution must be > 0")
         return ScanlineInputs(
-            faces_1based=np.asfortranarray(np.asarray(mesh.faces, dtype=np.int32) + 1),
-            facet_points=np.asfortranarray(np.asarray(self.sim.geom.face_incenters, dtype=float)),
-            face_normals=np.asfortranarray(np.asarray(mesh.face_normals, dtype=float)),
-            vertices=np.asfortranarray(np.asarray(mesh.vertices, dtype=float)),
+            faces_1based=self._scanline_faces_1based,
+            facet_points=self._scanline_facet_points,
+            face_normals=self._scanline_face_normals,
+            vertices=self._scanline_vertices,
             nsun=np.asfortranarray(np.asarray(nsun_unit, dtype=float)),
             irradiance=float(irradiance),
             resolution=float(resolution),

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -124,6 +124,79 @@ def _compute_ktot_and_z_edges(
     return ktot, z_edges, z_max, dz
 
 
+if nb is not None:
+
+    @nb.njit(cache=True)
+    def _build_cell_facet_lookup_numba(
+        triangles: np.ndarray,
+        dx: float,
+        dy: float,
+        z_edges: np.ndarray,
+        itot: int,
+        jtot: int,
+        ktot: int,
+        face_mask: np.ndarray,
+        use_face_mask: bool,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        n_cells = itot * jtot * ktot
+        n_facets = triangles.shape[0]
+        cell_counts = np.zeros(n_cells, dtype=np.int64)
+        cell_bounds = np.full((n_facets, 6), -1, dtype=np.int32)
+        eps = 1.0e-9 * max(dx, dy)
+
+        for fid in range(n_facets):
+            if use_face_mask and not face_mask[fid]:
+                continue
+            xmin = min(triangles[fid, 0, 0], triangles[fid, 1, 0], triangles[fid, 2, 0]) - eps
+            xmax = max(triangles[fid, 0, 0], triangles[fid, 1, 0], triangles[fid, 2, 0]) + eps
+            ymin = min(triangles[fid, 0, 1], triangles[fid, 1, 1], triangles[fid, 2, 1]) - eps
+            ymax = max(triangles[fid, 0, 1], triangles[fid, 1, 1], triangles[fid, 2, 1]) + eps
+            zmin = min(triangles[fid, 0, 2], triangles[fid, 1, 2], triangles[fid, 2, 2]) - eps
+            zmax = max(triangles[fid, 0, 2], triangles[fid, 1, 2], triangles[fid, 2, 2]) + eps
+            ix0 = int(math.floor(xmin / dx))
+            ix1 = int(math.floor(xmax / dx))
+            iy0 = int(math.floor(ymin / dy))
+            iy1 = int(math.floor(ymax / dy))
+            k0 = int(np.searchsorted(z_edges, zmin, side="right") - 1)
+            k1 = int(np.searchsorted(z_edges, zmax, side="right") - 1)
+            if ix1 < 0 or iy1 < 0 or k1 < 0:
+                continue
+            if ix0 >= itot or iy0 >= jtot or k0 >= ktot:
+                continue
+            ix0 = max(ix0, 0)
+            iy0 = max(iy0, 0)
+            k0 = max(k0, 0)
+            ix1 = min(ix1, itot - 1)
+            iy1 = min(iy1, jtot - 1)
+            k1 = min(k1, ktot - 1)
+            cell_bounds[fid] = (ix0, ix1, iy0, iy1, k0, k1)
+            for i in range(ix0, ix1 + 1):
+                for j in range(iy0, iy1 + 1):
+                    for k in range(k0, k1 + 1):
+                        cell_idx = i + itot * (j + jtot * k)
+                        cell_counts[cell_idx] += 1
+
+        cell_offsets = np.zeros(n_cells + 1, dtype=np.int64)
+        for cell_idx in range(n_cells):
+            cell_offsets[cell_idx + 1] = cell_offsets[cell_idx] + cell_counts[cell_idx]
+        cell_facets = np.empty(cell_offsets[-1], dtype=np.int32)
+        cell_cursor = cell_offsets[:-1].copy()
+
+        # Facet-order filling matches the old lexicographic (cell, facet) sort.
+        for fid in range(n_facets):
+            ix0, ix1, iy0, iy1, k0, k1 = cell_bounds[fid]
+            if ix0 < 0:
+                continue
+            for i in range(ix0, ix1 + 1):
+                for j in range(iy0, iy1 + 1):
+                    for k in range(k0, k1 + 1):
+                        cell_idx = i + itot * (j + jtot * k)
+                        pos = cell_cursor[cell_idx]
+                        cell_facets[pos] = fid
+                        cell_cursor[cell_idx] = pos + 1
+        return cell_offsets, cell_facets, cell_counts
+
+
 def _build_cell_facet_lookup(
     triangles: np.ndarray,
     dx: float,
@@ -135,57 +208,24 @@ def _build_cell_facet_lookup(
     face_mask: np.ndarray | None = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Build a cell->facet CSR lookup based on triangle AABB overlap."""
-    # Build a per-cell list of candidate facets by overlapping triangle AABBs with grid cells.
-    cell_idx_list = []
-    facet_idx_list = []
-    eps = 1.0e-9 * max(dx, dy)
-    for fid, tri in enumerate(triangles):
-        if face_mask is not None and not face_mask[fid]:
-            continue
-        vmin = tri.min(axis=0) - eps
-        vmax = tri.max(axis=0) + eps
-        ix0 = int(math.floor(vmin[0] / dx))
-        ix1 = int(math.floor(vmax[0] / dx))
-        iy0 = int(math.floor(vmin[1] / dy))
-        iy1 = int(math.floor(vmax[1] / dy))
-        k0 = int(np.searchsorted(z_edges, vmin[2], side="right") - 1)
-        k1 = int(np.searchsorted(z_edges, vmax[2], side="right") - 1)
-        if ix1 < 0 or iy1 < 0 or k1 < 0:
-            continue
-        if ix0 >= itot or iy0 >= jtot or k0 >= ktot:
-            continue
-        ix0 = max(ix0, 0)
-        iy0 = max(iy0, 0)
-        k0 = max(k0, 0)
-        ix1 = min(ix1, itot - 1)
-        iy1 = min(iy1, jtot - 1)
-        k1 = min(k1, ktot - 1)
-        for i in range(ix0, ix1 + 1):
-            for j in range(iy0, iy1 + 1):
-                for k in range(k0, k1 + 1):
-                    cell_idx_list.append(i + itot * (j + jtot * k))
-                    facet_idx_list.append(fid)
-    if not cell_idx_list:
-        n_cells = itot * jtot * ktot
-        cell_offsets = np.zeros(n_cells + 1, dtype=np.int64)
-        cell_facets = np.zeros(0, dtype=np.int32)
-        cell_has_facets = np.zeros((itot, jtot, ktot), dtype=bool)
-        return cell_offsets, cell_facets, cell_has_facets
-    cell_idx = np.asarray(cell_idx_list, dtype=np.int64)
-    facet_idx = np.asarray(facet_idx_list, dtype=np.int32)
-    # Sort and de-duplicate (cell, facet) pairs, then build a CSR lookup.
-    order = np.lexsort((facet_idx, cell_idx))
-    cell_idx = cell_idx[order]
-    facet_idx = facet_idx[order]
-    uniq = np.ones(len(cell_idx), dtype=bool)
-    uniq[1:] = (cell_idx[1:] != cell_idx[:-1]) | (facet_idx[1:] != facet_idx[:-1])
-    cell_idx = cell_idx[uniq]
-    facet_idx = facet_idx[uniq]
-    n_cells = itot * jtot * ktot
-    counts = np.bincount(cell_idx, minlength=n_cells).astype(np.int64)
-    cell_offsets = np.zeros(n_cells + 1, dtype=np.int64)
-    cell_offsets[1:] = np.cumsum(counts, dtype=np.int64)
-    cell_facets = facet_idx.astype(np.int32)
+    _require_numba()
+    use_face_mask = face_mask is not None
+    mask = (
+        np.asarray(face_mask, dtype=bool)
+        if use_face_mask
+        else np.empty(0, dtype=bool)
+    )
+    cell_offsets, cell_facets, counts = _build_cell_facet_lookup_numba(
+        np.asarray(triangles, dtype=float),
+        float(dx),
+        float(dy),
+        np.asarray(z_edges, dtype=float),
+        int(itot),
+        int(jtot),
+        int(ktot),
+        mask,
+        use_face_mask,
+    )
     cell_has_facets = counts.reshape((itot, jtot, ktot), order="F") > 0
     return cell_offsets, cell_facets, cell_has_facets
 

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -344,7 +344,6 @@ if nb is not None:
         veg_index: np.ndarray,
         solid: np.ndarray,
         has_solid: bool,
-        energy_in: np.ndarray,
         solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
@@ -355,8 +354,6 @@ if nb is not None:
         irradiance: float,
         periodic_xy: bool,
         max_ray_length: float,
-        enable_hit_count: bool,
-        hit_count: np.ndarray,
         allow_outside_xy: bool,
     ) -> float:
         x, y, z = origin
@@ -447,12 +444,6 @@ if nb is not None:
                     ii = i
                     jj = j
 
-            if enable_hit_count:
-                if inside:
-                    hit_count[ii, jj, k] += 1
-            if inside:
-                energy_in[ii, jj, k] += r_in * irradiance * ray_area
-
             t_next = min(t_max_x, t_max_y, t_max_z)
             if t_next > max_ray_length:
                 ds = max_ray_length - t
@@ -516,7 +507,6 @@ if nb is not None:
         cell_facets: np.ndarray,
         triangles: np.ndarray,
         facet_hit_energy: np.ndarray,
-        energy_in: np.ndarray,
         solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
@@ -527,8 +517,6 @@ if nb is not None:
         irradiance: float,
         periodic_xy: bool,
         max_ray_length: float,
-        enable_hit_count: bool,
-        hit_count: np.ndarray,
         allow_outside_xy: bool,
         debug_facid: int,
         debug_min_t: np.ndarray,
@@ -609,11 +597,6 @@ if nb is not None:
             else:
                 ii = i
                 jj = j
-            if enable_hit_count and base_inside:
-                hit_count[ii, jj, k] += 1
-            if base_inside:
-                energy_in[ii, jj, k] += r_in * irradiance * ray_area
-
             t_next = min(t_max_x, t_max_y, t_max_z)
             t_limit = t_next
             if t_limit > max_ray_length:
@@ -844,7 +827,6 @@ if nb is not None:
         cell_facets: np.ndarray,
         triangles: np.ndarray,
         facet_hit_energy: np.ndarray,
-        energy_in: np.ndarray,
         solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
@@ -855,8 +837,6 @@ if nb is not None:
         irradiance: float,
         periodic_xy: bool,
         max_ray_length: float,
-        enable_hit_count: bool,
-        hit_count: np.ndarray,
         allow_outside_xy: bool,
         debug_facid: int,
         debug_min_t: np.ndarray,
@@ -903,7 +883,6 @@ if nb is not None:
                     cell_facets,
                     triangles,
                     facet_hit_energy,
-                    energy_in,
                     solid_hit_energy,
                     veg_absorb,
                     ray_area,
@@ -914,8 +893,6 @@ if nb is not None:
                     irradiance,
                     periodic_xy,
                     max_ray_length,
-                    enable_hit_count,
-                    hit_count,
                     allow_outside_xy,
                     debug_facid,
                     debug_min_t,
@@ -945,7 +922,6 @@ if nb is not None:
         veg_index: np.ndarray,
         solid: np.ndarray,
         has_solid: bool,
-        energy_in: np.ndarray,
         solid_hit_energy: np.ndarray,
         veg_absorb: np.ndarray,
         ray_area: float,
@@ -956,8 +932,6 @@ if nb is not None:
         irradiance: float,
         periodic_xy: bool,
         max_ray_length: float,
-        enable_hit_count: bool,
-        hit_count: np.ndarray,
         allow_outside_xy: bool,
         bud_in: np.ndarray,
         bud_out: np.ndarray,
@@ -997,7 +971,6 @@ if nb is not None:
                     veg_index,
                     solid,
                     has_solid,
-                    energy_in,
                     solid_hit_energy,
                     veg_absorb,
                     ray_area,
@@ -1008,8 +981,6 @@ if nb is not None:
                     irradiance,
                     periodic_xy,
                     max_ray_length,
-                    enable_hit_count,
-                    hit_count,
                     allow_outside_xy,
                 )
 
@@ -1327,7 +1298,6 @@ class DirectShortwaveSolver:
             jitter_u = np.zeros(bud["rays"], dtype=float)
             jitter_v = np.zeros(bud["rays"], dtype=float)
 
-        energy_in = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
         solid_hit_energy = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
         veg_absorb = np.zeros(len(self.veg.points), dtype=float)
         facet_hit_energy = np.zeros(self.nfaces, dtype=float)
@@ -1359,7 +1329,6 @@ class DirectShortwaveSolver:
             self.cell_facets,
             self.triangles,
             facet_hit_energy,
-            energy_in,
             solid_hit_energy,
             veg_absorb,
             ray_area,
@@ -1370,8 +1339,6 @@ class DirectShortwaveSolver:
             irradiance,
             periodic_xy,
             10.0 * max(self.sim.xlen, self.sim.ylen),
-            False,
-            np.zeros((1, 1, 1), dtype=np.int32),
             True,
             -1,
             np.array([np.inf], dtype=float),
@@ -1439,7 +1406,6 @@ class DirectShortwaveSolver:
         ray_area = step * step
         use_jitter = self.ray_jitter > 0.0
 
-        energy_in = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
         solid_hit_energy = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
         veg_absorb = np.zeros(len(self.veg.points), dtype=float)
 
@@ -1478,7 +1444,6 @@ class DirectShortwaveSolver:
             self.veg_index,
             self.solid,
             self.has_solid,
-            energy_in,
             solid_hit_energy,
             veg_absorb,
             ray_area,
@@ -1489,8 +1454,6 @@ class DirectShortwaveSolver:
             irradiance,
             periodic_xy,
             10.0 * max(self.sim.xlen, self.sim.ylen),
-            False,
-            np.zeros((1, 1, 1), dtype=np.int32),
             True,
             bud_in,
             bud_out,

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -309,6 +309,62 @@ if nb is not None:
         return i, j, k
 
     @nb.njit(cache=True)
+    def _ray_box_intersection_scalar_numba(
+        ox: float,
+        oy: float,
+        oz: float,
+        dir_x: float,
+        dir_y: float,
+        dir_z: float,
+        xmin: float,
+        ymin: float,
+        zmin: float,
+        xmax: float,
+        ymax: float,
+        zmax: float,
+    ) -> Tuple[float, float]:
+        t_min = -math.inf
+        t_max = math.inf
+
+        if abs(dir_x) < 1.0e-12:
+            if ox < xmin or ox > xmax:
+                return math.inf, -math.inf
+        else:
+            inv_d = 1.0 / dir_x
+            t0 = (xmin - ox) * inv_d
+            t1 = (xmax - ox) * inv_d
+            if t0 > t1:
+                t0, t1 = t1, t0
+            t_min = max(t_min, t0)
+            t_max = min(t_max, t1)
+
+        if abs(dir_y) < 1.0e-12:
+            if oy < ymin or oy > ymax:
+                return math.inf, -math.inf
+        else:
+            inv_d = 1.0 / dir_y
+            t0 = (ymin - oy) * inv_d
+            t1 = (ymax - oy) * inv_d
+            if t0 > t1:
+                t0, t1 = t1, t0
+            t_min = max(t_min, t0)
+            t_max = min(t_max, t1)
+
+        if abs(dir_z) < 1.0e-12:
+            if oz < zmin or oz > zmax:
+                return math.inf, -math.inf
+        else:
+            inv_d = 1.0 / dir_z
+            t0 = (zmin - oz) * inv_d
+            t1 = (zmax - oz) * inv_d
+            if t0 > t1:
+                t0, t1 = t1, t0
+            t_min = max(t_min, t0)
+            t_max = min(t_max, t1)
+
+        return t_min, t_max
+
+    @nb.njit(cache=True)
     def _ray_box_intersection_numba(
         origin: np.ndarray,
         direction: np.ndarray,
@@ -333,8 +389,12 @@ if nb is not None:
 
     @nb.njit(cache=True)
     def _trace_ray_facsec_numba(
-        origin: np.ndarray,
-        direction: np.ndarray,
+        x: float,
+        y: float,
+        z: float,
+        dir_x: float,
+        dir_y: float,
+        dir_z: float,
         dx: float,
         dy: float,
         z_edges: np.ndarray,
@@ -356,8 +416,6 @@ if nb is not None:
         max_ray_length: float,
         allow_outside_xy: bool,
     ) -> float:
-        x, y, z = origin
-
         i, j, k = _point_to_cell_numba(
             x,
             y,
@@ -374,7 +432,6 @@ if nb is not None:
         if i < 0:
             return 0.0
 
-        dir_x, dir_y, dir_z = direction
         step_x = 0 if dir_x == 0.0 else (1 if dir_x > 0.0 else -1)
         step_y = 0 if dir_y == 0.0 else (1 if dir_y > 0.0 else -1)
         step_z = 0 if dir_z == 0.0 else (1 if dir_z > 0.0 else -1)
@@ -938,10 +995,16 @@ if nb is not None:
     ) -> None:
         nu = u_vals.shape[0]
         nv = v_vals.shape[0]
-        idx = 0
+        p0x, p0y, p0z = p0
+        u1x, u1y, u1z = u1
+        u2x, u2y, u2z = u2
+        dir_x, dir_y, dir_z = direction
+        xmin, ymin, zmin = bounds_min
+        xmax, ymax, zmax = bounds_max
         for iu in range(nu):
             u = u_vals[iu]
             for iv in range(nv):
+                idx = iu * nv + iv
                 v = v_vals[iv]
                 if use_jitter:
                     u_use = u + jitter_u[idx]
@@ -949,19 +1012,40 @@ if nb is not None:
                 else:
                     u_use = u
                     v_use = v
-                idx += 1
-                origin = p0 + u1 * u_use + u2 * v_use
-                t0, t1 = _ray_box_intersection_numba(origin, direction, bounds_min, bounds_max)
+                ox = p0x + u1x * u_use + u2x * v_use
+                oy = p0y + u1y * u_use + u2y * v_use
+                oz = p0z + u1z * u_use + u2z * v_use
+                t0, t1 = _ray_box_intersection_scalar_numba(
+                    ox,
+                    oy,
+                    oz,
+                    dir_x,
+                    dir_y,
+                    dir_z,
+                    xmin,
+                    ymin,
+                    zmin,
+                    xmax,
+                    ymax,
+                    zmax,
+                )
                 if t1 < t0:
                     continue
                 if t1 < 0.0:
                     continue
                 bud_in[0] += irradiance * ray_area
                 entry = t0 if t0 > 0.0 else 0.0
-                start = origin + direction * (entry + 1.0e-6)
+                start_offset = entry + 1.0e-6
+                sx = ox + dir_x * start_offset
+                sy = oy + dir_y * start_offset
+                sz = oz + dir_z * start_offset
                 bud_out[0] += _trace_ray_facsec_numba(
-                    start,
-                    direction,
+                    sx,
+                    sy,
+                    sz,
+                    dir_x,
+                    dir_y,
+                    dir_z,
                     dx,
                     dy,
                     z_edges,

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -1440,8 +1440,8 @@ class DirectShortwaveSolver:
             jitter_u = (rng.random(bud["rays"]) - 0.5) * step * self.ray_jitter
             jitter_v = (rng.random(bud["rays"]) - 0.5) * step * self.ray_jitter
         else:
-            jitter_u = np.zeros(bud["rays"], dtype=float)
-            jitter_v = np.zeros(bud["rays"], dtype=float)
+            jitter_u = np.empty(0, dtype=float)
+            jitter_v = np.empty(0, dtype=float)
 
         solid_hit_energy = np.zeros((self.sim.itot, self.sim.jtot, self.ktot), dtype=float)
         facet_hit_energy = np.zeros(self.nfaces, dtype=float)
@@ -1606,8 +1606,8 @@ class DirectShortwaveSolver:
             jitter_u = (rng.random(bud["rays"]) - 0.5) * step * self.ray_jitter
             jitter_v = (rng.random(bud["rays"]) - 0.5) * step * self.ray_jitter
         else:
-            jitter_u = np.zeros(bud["rays"], dtype=float)
-            jitter_v = np.zeros(bud["rays"], dtype=float)
+            jitter_u = np.empty(0, dtype=float)
+            jitter_v = np.empty(0, dtype=float)
 
         thread_count = nb.get_num_threads()
         veg_absorb_thread = np.zeros(

--- a/tools/python/udprep/directshortwave.py
+++ b/tools/python/udprep/directshortwave.py
@@ -294,10 +294,6 @@ if nb is not None:
         cell_facets: np.ndarray,
         cell_idx: int,
         t_max: float,
-        debug_facid: int,
-        debug_min_t: np.ndarray,
-        debug_count: np.ndarray,
-        debug_test_count: np.ndarray,
     ) -> Tuple[float, int]:
         start = cell_offsets[cell_idx]
         end = cell_offsets[cell_idx + 1]
@@ -307,8 +303,6 @@ if nb is not None:
         best_fid = -1
         for idx in range(start, end):
             fid = cell_facets[idx]
-            if debug_facid >= 0 and fid == debug_facid:
-                debug_test_count[0] += 1
             v0 = triangles[fid, 0]
             v1 = triangles[fid, 1]
             v2 = triangles[fid, 2]
@@ -316,10 +310,6 @@ if nb is not None:
             if hit and t < best:
                 best = t
                 best_fid = fid
-            if debug_facid >= 0 and fid == debug_facid and hit:
-                if t < debug_min_t[0]:
-                    debug_min_t[0] = t
-                debug_count[0] += 1
         if best <= t_max:
             return best, best_fid
         return -1.0, -1
@@ -619,10 +609,6 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-        debug_facid: int,
-        debug_min_t: np.ndarray,
-        debug_count: np.ndarray,
-        debug_test_count: np.ndarray,
     ) -> float:
         x, y, z = origin
 
@@ -732,10 +718,6 @@ if nb is not None:
                     cell_facets,
                     cell_idx,
                     ds,
-                    debug_facid,
-                    debug_min_t,
-                    debug_count,
-                    debug_test_count,
                 )
                 if t_hit >= 0.0:
                     # Limit the segment to the hit point; the facet is credited
@@ -939,10 +921,6 @@ if nb is not None:
         periodic_xy: bool,
         max_ray_length: float,
         allow_outside_xy: bool,
-        debug_facid: int,
-        debug_min_t: np.ndarray,
-        debug_count: np.ndarray,
-        debug_test_count: np.ndarray,
         bud_in: np.ndarray,
         bud_out: np.ndarray,
     ) -> None:
@@ -995,10 +973,6 @@ if nb is not None:
                     periodic_xy,
                     max_ray_length,
                     allow_outside_xy,
-                    debug_facid,
-                    debug_min_t,
-                    debug_count,
-                    debug_test_count,
                 )
 
     @nb.njit(cache=True, parallel=True)
@@ -1496,10 +1470,6 @@ class DirectShortwaveSolver:
             periodic_xy,
             10.0 * max(self.sim.xlen, self.sim.ylen),
             True,
-            -1,
-            np.array([np.inf], dtype=float),
-            np.array([0], dtype=np.int64),
-            np.array([0], dtype=np.int64),
             bud_in,
             bud_out,
         )

--- a/tools/python/udprep/harmonie_radiation.py
+++ b/tools/python/udprep/harmonie_radiation.py
@@ -21,6 +21,12 @@ from typing import Any, Iterable
 import numpy as np
 
 from . import _radiation_compute
+from .radiation_timing import (
+    ShortwaveTimingRecorder,
+    Stopwatch,
+    benchmark_metadata,
+    timed_stage,
+)
 from .solar import nsun_from_angles, solar_position_python
 
 
@@ -835,8 +841,10 @@ def map_atmosphere_to_facets(
     *,
     method: str | None = None,
     verbose: bool = True,
+    timing: ShortwaveTimingRecorder | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
     """Map atmospheric shortwave forcing to uDALES facets."""
+    setup_timer = Stopwatch() if timing is not None else None
     sim = prep.sim
     radiation = prep.radiation
     lscatter = bool(radiation.lEB)
@@ -857,11 +865,31 @@ def map_atmosphere_to_facets(
     sdir_all = np.zeros((nfacets, nt), dtype=np.float32)
     knet_all = np.zeros((nfacets, nt), dtype=np.float32)
     sveg_all: np.ndarray | None = None
+    if timing is not None and setup_timer is not None:
+        timing.record_stage("facet_mapping_setup", setup_timer.sample())
+
+    model_start = None
+    if timing is not None:
+        model_timezone = timezone(
+            timedelta(hours=float(getattr(radiation, "timezone", 0.0)))
+        )
+        model_start = datetime(
+            int(radiation.year),
+            int(radiation.month),
+            int(radiation.day),
+            int(radiation.hour),
+            int(radiation.minute),
+            int(radiation.second),
+            tzinfo=model_timezone,
+        )
 
     for idx, time_value in enumerate(atmosphere.times):
+        step_timer = Stopwatch() if timing is not None else None
+        step_timing: dict[str, float] = {}
         dni = float(atmosphere.dni[idx])
         dsky = float(atmosphere.dsky[idx])
         zenith = float(atmosphere.zenith[idx])
+        mode = "night"
         if verbose:
             print(
                 f"[{idx + 1:3d}/{nt}] t={time_value:8.1f}s "
@@ -873,6 +901,8 @@ def map_atmosphere_to_facets(
         if dni > 0.0 and zenith < 90.0:
             nsun = nsun_from_angles(zenith, float(atmosphere.azimuth_local[idx]))
             if abs(float(nsun[2])) >= MIN_DIRECT_COS_ZENITH:
+                mode = "direct"
+                timing_args = {"timing": step_timing} if timing is not None else {}
                 sdir, knet, sveg = radiation._compute_knet(
                     nsun,
                     dni,
@@ -884,6 +914,7 @@ def map_atmosphere_to_facets(
                     vf,
                     svf,
                     fss,
+                    **timing_args,
                 )
                 sdir_all[:, idx] = np.asarray(sdir, dtype=np.float32)
                 knet_all[:, idx] = np.asarray(knet, dtype=np.float32)
@@ -891,10 +922,14 @@ def map_atmosphere_to_facets(
                     if sveg_all is None:
                         sveg_all = np.zeros((np.asarray(sveg).size, nt), dtype=np.float32)
                     sveg_all[:, idx] = np.asarray(sveg, dtype=np.float32)
-                continue
+            elif dsky > 0.0:
+                mode = "diffuse"
+        elif dsky > 0.0:
+            mode = "diffuse"
 
-        if dsky > 0.0:
+        if mode == "diffuse":
             zero_sdir = np.zeros(nfacets, dtype=np.float64)
+            net_timer = Stopwatch() if timing is not None else None
             if lscatter:
                 if vf is None or svf is None:
                     raise ValueError("View factors are required for diffuse shortwave")
@@ -906,6 +941,50 @@ def map_atmosphere_to_facets(
                     zero_sdir, dsky, fss, albedo
                 )
             knet_all[:, idx] = np.asarray(knet, dtype=np.float32)
+            if net_timer is not None:
+                net_sample = net_timer.sample()
+                step_timing["net_wall_seconds"] = net_sample.wall_seconds
+                step_timing["net_cpu_seconds"] = net_sample.cpu_seconds
+
+        if timing is not None and step_timer is not None:
+            if model_start is None:
+                raise RuntimeError("Internal error: benchmark model start is unavailable")
+            step_sample = step_timer.sample()
+            timing.record_timestamp(
+                {
+                    "index": idx + 1,
+                    "total": nt,
+                    "model_time_seconds": float(time_value),
+                    "simulation_datetime": (
+                        model_start + timedelta(seconds=float(time_value))
+                    ).isoformat(),
+                    "mode": mode,
+                    "ghi_w_m2": float(atmosphere.ghi[idx]),
+                    "dni_w_m2": dni,
+                    "dsky_w_m2": dsky,
+                    "zenith_degrees": zenith,
+                    "azimuth_local_degrees": float(atmosphere.azimuth_local[idx]),
+                    "direct_wall_seconds": step_timing.get("direct_wall_seconds", 0.0),
+                    "direct_cpu_seconds": step_timing.get("direct_cpu_seconds", 0.0),
+                    "net_wall_seconds": step_timing.get("net_wall_seconds", 0.0),
+                    "net_cpu_seconds": step_timing.get("net_cpu_seconds", 0.0),
+                    "step_wall_seconds": step_sample.wall_seconds,
+                    "step_cpu_seconds": step_sample.cpu_seconds,
+                }
+            )
+            if verbose:
+                peak_text = (
+                    f"{step_sample.peak_rss_mib:.1f} MiB"
+                    if step_sample.peak_rss_mib is not None
+                    else "n/a"
+                )
+                print(
+                    f"[timing {idx + 1:3d}/{nt}] mode={mode:<7s} "
+                    f"wall={step_sample.wall_seconds:.3f}s "
+                    f"cpu={step_sample.cpu_seconds:.3f}s "
+                    f"peak_rss={peak_text}",
+                    flush=True,
+                )
 
     return sdir_all, knet_all, sveg_all
 
@@ -924,6 +1003,84 @@ def generate_timedepsw_from_harmonie(
     atmos_only: bool = False,
     method: str | None = None,
     verbose: bool = True,
+    timing_prefix: Path | None = None,
+) -> TimedepShortwaveResult | ShortwaveAtmosphere:
+    """Generate HARMONIE shortwave inputs with optional benchmark timing."""
+    case_dir = Path(case_dir).expanduser().resolve()
+    timing = None
+    if timing_prefix is not None:
+        repo_root = Path(__file__).resolve().parents[3]
+        metadata = benchmark_metadata(repo_root, case_dir)
+        metadata.update(
+            {
+                "nwp_root": str(Path(nwp_root).expanduser()),
+                "version": version,
+                "method_override": method,
+                "atmos_only": atmos_only,
+            }
+        )
+        timing = ShortwaveTimingRecorder(
+            timing_prefix,
+            metadata=metadata,
+            overwrite=overwrite,
+        )
+
+    total_timer = Stopwatch()
+    try:
+        result = _generate_timedepsw_from_harmonie(
+            case_dir=case_dir,
+            nwp_root=nwp_root,
+            version=version,
+            data_dir=data_dir,
+            download=download,
+            output=output,
+            sdir_nc=sdir_nc,
+            write_sdir_nc=write_sdir_nc,
+            overwrite=overwrite,
+            atmos_only=atmos_only,
+            method=method,
+            verbose=verbose,
+            timing=timing,
+        )
+    except BaseException as exc:
+        if timing is not None:
+            timing.finish(
+                status="failed",
+                total=total_timer.sample(),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        raise
+
+    if timing is not None:
+        outputs = None
+        if isinstance(result, TimedepShortwaveResult):
+            outputs = {
+                "timedepsw": str(result.timedepsw_path),
+                "netsw": str(result.netsw_path),
+                "sdir_nc": str(result.sdir_nc_path) if result.sdir_nc_path else None,
+                "timedepsveg": (
+                    str(result.timedepsveg_path) if result.timedepsveg_path else None
+                ),
+            }
+        timing.finish(status="completed", total=total_timer.sample(), outputs=outputs)
+    return result
+
+
+def _generate_timedepsw_from_harmonie(
+    *,
+    case_dir: Path,
+    nwp_root: Path = DEFAULT_NWP_ROOT,
+    version: str = DEFAULT_VERSION,
+    data_dir: Path | None = None,
+    download: bool = False,
+    output: Path | None = None,
+    sdir_nc: Path | None = None,
+    write_sdir_nc: bool = True,
+    overwrite: bool = False,
+    atmos_only: bool = False,
+    method: str | None = None,
+    verbose: bool = True,
+    timing: ShortwaveTimingRecorder | None = None,
 ) -> TimedepShortwaveResult | ShortwaveAtmosphere:
     """Generate ``timedepsw.inp.<expnr>`` from HARMONIE ``ssrd``.
 
@@ -934,30 +1091,48 @@ def generate_timedepsw_from_harmonie(
     expnr = case_dir.name
 
     prep = None
-    if atmos_only:
-        radiation = radiation_config_from_case_dir(case_dir)
-    else:
-        try:
-            from .udprep import UDPrep
-        except ImportError as exc:
-            raise RuntimeError(
-                "Facet mapping requires the uDALES preprocessing environment "
-                "(geometry/radiation dependencies such as trimesh, triangle, "
-                "netCDF4, and directshortwave_f2py) in addition to the HARMONIE "
-                "GRIB dependencies (xarray, cfgrib, pyproj)."
-            ) from exc
+    with timed_stage(timing, "load_case_geometry"):
+        if atmos_only:
+            radiation = radiation_config_from_case_dir(case_dir)
+        else:
+            try:
+                from .udprep import UDPrep
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Facet mapping requires the uDALES preprocessing environment "
+                    "(geometry/radiation dependencies such as trimesh, triangle, "
+                    "netCDF4, and directshortwave_f2py) in addition to the HARMONIE "
+                    "GRIB dependencies (xarray, cfgrib, pyproj)."
+                ) from exc
 
-        prep = UDPrep(expnr, case_dir, load_geometry=True)
-        radiation = prep.radiation
+            prep = UDPrep(expnr, case_dir, load_geometry=True)
+            radiation = prep.radiation
 
-    atmosphere, reader = prepare_harmonie_ssrd_atmosphere(
-        radiation=radiation,
-        nwp_root=nwp_root,
-        version=version,
-        data_dir=data_dir,
-        download=download,
-        verbose=verbose,
-    )
+    if timing is not None:
+        runtime_value = getattr(radiation, "runtime", None)
+        dtsp_value = getattr(radiation, "dtSP", None)
+        ntimedepsw_value = getattr(radiation, "ntimedepsw", None)
+        timing.update_metadata(
+            experiment=expnr,
+            runtime_seconds=(float(runtime_value) if runtime_value is not None else None),
+            dtsp_seconds=(float(dtsp_value) if dtsp_value is not None else None),
+            ntimedepsw=(
+                int(ntimedepsw_value) if ntimedepsw_value is not None else None
+            ),
+            ishortwave=getattr(radiation, "ishortwave", None),
+            psc_res=getattr(radiation, "psc_res", None),
+            energy_balance=bool(getattr(radiation, "lEB", False)),
+        )
+
+    with timed_stage(timing, "prepare_harmonie_atmosphere"):
+        atmosphere, reader = prepare_harmonie_ssrd_atmosphere(
+            radiation=radiation,
+            nwp_root=nwp_root,
+            version=version,
+            data_dir=data_dir,
+            download=download,
+            verbose=verbose,
+        )
     if verbose:
         print(f"Spatial mask points: {reader.mask_points}")
         print(
@@ -995,18 +1170,29 @@ def generate_timedepsw_from_harmonie(
         paths_to_check.append(sdir_nc_path)
     _check_output_paths(paths_to_check, overwrite=overwrite)
 
-    sdir, knet, sveg = map_atmosphere_to_facets(
-        prep, atmosphere, method=method, verbose=verbose
-    )
+    with timed_stage(timing, "map_atmosphere_to_facets"):
+        sdir, knet, sveg = map_atmosphere_to_facets(
+            prep,
+            atmosphere,
+            method=method,
+            verbose=verbose,
+            timing=timing,
+        )
 
-    write_timedepsw(timedepsw_path, atmosphere.times, knet, overwrite=overwrite)
-    write_netsw(netsw_path, knet[:, 0], overwrite=overwrite)
+    with timed_stage(timing, "write_timedepsw"):
+        write_timedepsw(timedepsw_path, atmosphere.times, knet, overwrite=overwrite)
+    with timed_stage(timing, "write_netsw"):
+        write_netsw(netsw_path, knet[:, 0], overwrite=overwrite)
     if sdir_nc_path is not None:
-        prep.radiation._write_sdir_nc(sdir_nc_path, atmosphere.times, sdir)
+        with timed_stage(timing, "write_sdir_nc"):
+            prep.radiation._write_sdir_nc(sdir_nc_path, atmosphere.times, sdir)
     written_sveg_path = None
     if sveg is not None:
         _check_output_paths([timedepsveg_path], overwrite=overwrite)
-        write_timedepsveg(timedepsveg_path, atmosphere.times, sveg, overwrite=overwrite)
+        with timed_stage(timing, "write_timedepsveg"):
+            write_timedepsveg(
+                timedepsveg_path, atmosphere.times, sveg, overwrite=overwrite
+            )
         written_sveg_path = timedepsveg_path
 
     return TimedepShortwaveResult(

--- a/tools/python/udprep/harmonie_radiation.py
+++ b/tools/python/udprep/harmonie_radiation.py
@@ -1139,6 +1139,12 @@ def map_atmosphere_to_facets(
         if not verbose:
             return
         time_value = atmosphere.times[idx]
+        if timing is None:
+            print(
+                f"[{prefix} {idx + 1:3d}/{nt}] t={time_value:8.1f}s",
+                flush=True,
+            )
+            return
         dni = float(atmosphere.dni[idx])
         dsky = float(atmosphere.dsky[idx])
         zenith = float(atmosphere.zenith[idx])
@@ -1202,7 +1208,7 @@ def map_atmosphere_to_facets(
                 }
             )
 
-        if verbose:
+        if verbose and timing is not None:
             peak_text = (
                 f"{result.sample.peak_rss_mib:.1f} MiB"
                 if result.sample.peak_rss_mib is not None
@@ -1214,6 +1220,16 @@ def map_atmosphere_to_facets(
                 f"wall={result.sample.wall_seconds:.3f}s "
                 f"cpu={result.sample.cpu_seconds:.3f}s "
                 f"peak_rss={peak_text} pid={result.worker_pid}",
+                flush=True,
+            )
+        elif verbose:
+            action = "resumed" if result.resumed else "done"
+            wall_text = (
+                "" if result.resumed else f" wall={result.sample.wall_seconds:.3f}s"
+            )
+            print(
+                f"[{action} {idx + 1:3d}/{nt}] "
+                f"mode={result.mode:<7s}{wall_text}",
                 flush=True,
             )
 

--- a/tools/python/udprep/harmonie_radiation.py
+++ b/tools/python/udprep/harmonie_radiation.py
@@ -9,7 +9,11 @@ shortwave-reflection machinery.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import multiprocessing
+import os
 import runpy
 import subprocess
 import sys
@@ -24,6 +28,7 @@ from . import _radiation_compute
 from .radiation_timing import (
     ShortwaveTimingRecorder,
     Stopwatch,
+    TimingSample,
     benchmark_metadata,
     timed_stage,
 )
@@ -113,6 +118,33 @@ class TimedepShortwaveResult:
     netsw_path: Path
     sdir_nc_path: Path | None
     timedepsveg_path: Path | None
+
+
+@dataclass(frozen=True)
+class _FacetMappingContext:
+    radiation: Any
+    atmosphere: ShortwaveAtmosphere
+    method: str
+    resolution: float | None
+    lscatter: bool
+    albedo: np.ndarray
+    vf: Any
+    svf: np.ndarray | None
+    fss: np.ndarray | None
+    nfacets: int
+
+
+@dataclass(frozen=True)
+class _FacetStepResult:
+    index: int
+    mode: str
+    sdir: np.ndarray | None
+    knet: np.ndarray | None
+    sveg: np.ndarray | None
+    timing: dict[str, float]
+    sample: TimingSample
+    worker_pid: int
+    resumed: bool = False
 
 
 @dataclass(frozen=True)
@@ -835,6 +867,199 @@ def _check_output_paths(paths: Iterable[Path], *, overwrite: bool) -> None:
         )
 
 
+_FACET_MAPPING_CONTEXT: _FacetMappingContext | None = None
+
+
+def _compute_facet_step(context: _FacetMappingContext, idx: int) -> _FacetStepResult:
+    timer = Stopwatch()
+    atmosphere = context.atmosphere
+    radiation = context.radiation
+    dni = float(atmosphere.dni[idx])
+    dsky = float(atmosphere.dsky[idx])
+    zenith = float(atmosphere.zenith[idx])
+    mode = "night"
+    sdir_result = None
+    knet_result = None
+    sveg_result = None
+    step_timing: dict[str, float] = {}
+
+    if dni > 0.0 and zenith < 90.0:
+        nsun = nsun_from_angles(zenith, float(atmosphere.azimuth_local[idx]))
+        if abs(float(nsun[2])) >= MIN_DIRECT_COS_ZENITH:
+            mode = "direct"
+            sdir, knet, sveg = radiation._compute_knet(
+                nsun,
+                dni,
+                dsky,
+                context.method,
+                context.resolution,
+                context.lscatter,
+                context.albedo,
+                context.vf,
+                context.svf,
+                context.fss,
+                timing=step_timing,
+            )
+            sdir_result = np.asarray(sdir, dtype=np.float32)
+            knet_result = np.asarray(knet, dtype=np.float32)
+            if sveg is not None and np.asarray(sveg).size > 0:
+                sveg_result = np.asarray(sveg, dtype=np.float32)
+        elif dsky > 0.0:
+            mode = "diffuse"
+    elif dsky > 0.0:
+        mode = "diffuse"
+
+    if mode == "diffuse":
+        zero_sdir = np.zeros(context.nfacets, dtype=np.float64)
+        net_timer = Stopwatch()
+        if context.lscatter:
+            if context.vf is None or context.svf is None:
+                raise ValueError("View factors are required for diffuse shortwave")
+            knet = radiation.calc_reflections_sw(
+                zero_sdir,
+                dsky,
+                context.vf,
+                context.svf,
+                context.albedo,
+            )
+        else:
+            if context.fss is None:
+                raise ValueError("Fss is required for non-scattering shortwave")
+            knet = _radiation_compute.net_shortwave_nonscattering(
+                zero_sdir, dsky, context.fss, context.albedo
+            )
+        net_sample = net_timer.sample()
+        step_timing["net_wall_seconds"] = net_sample.wall_seconds
+        step_timing["net_cpu_seconds"] = net_sample.cpu_seconds
+        knet_result = np.asarray(knet, dtype=np.float32)
+
+    return _FacetStepResult(
+        index=idx,
+        mode=mode,
+        sdir=sdir_result,
+        knet=knet_result,
+        sveg=sveg_result,
+        timing=step_timing,
+        sample=timer.sample(),
+        worker_pid=os.getpid(),
+    )
+
+
+def _facet_mapping_worker(idx: int) -> _FacetStepResult:
+    if _FACET_MAPPING_CONTEXT is None:
+        raise RuntimeError("Facet mapping worker was not initialized")
+    return _compute_facet_step(_FACET_MAPPING_CONTEXT, idx)
+
+
+def _checkpoint_manifest(context: _FacetMappingContext) -> dict[str, Any]:
+    times = np.ascontiguousarray(context.atmosphere.times, dtype=np.float64)
+    return {
+        "schema_version": 1,
+        "nfacets": context.nfacets,
+        "ntimestamps": int(times.size),
+        "times_sha256": hashlib.sha256(times.tobytes()).hexdigest(),
+        "method": context.method,
+        "resolution": context.resolution,
+        "lscatter": context.lscatter,
+    }
+
+
+def _prepare_checkpoint_dir(
+    checkpoint_dir: Path,
+    context: _FacetMappingContext,
+    *,
+    resume: bool,
+) -> Path:
+    checkpoint_dir = Path(checkpoint_dir).expanduser().resolve()
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = checkpoint_dir / "manifest.json"
+    expected = _checkpoint_manifest(context)
+    if manifest_path.exists():
+        existing = json.loads(manifest_path.read_text(encoding="ascii"))
+        if resume and existing != expected:
+            raise ValueError(
+                f"Checkpoint manifest does not match this run: {manifest_path}"
+            )
+    temp_path = checkpoint_dir / f".manifest.{os.getpid()}.tmp"
+    with temp_path.open("w", encoding="ascii") as handle:
+        json.dump(expected, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    temp_path.replace(manifest_path)
+    return checkpoint_dir
+
+
+def _checkpoint_path(checkpoint_dir: Path, idx: int) -> Path:
+    return checkpoint_dir / f"step_{idx + 1:06d}.npz"
+
+
+def _write_step_checkpoint(
+    checkpoint_dir: Path,
+    result: _FacetStepResult,
+    model_time_seconds: float,
+) -> None:
+    path = _checkpoint_path(checkpoint_dir, result.index)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with temp_path.open("wb") as handle:
+        np.savez(
+            handle,
+            index=np.int64(result.index),
+            model_time_seconds=np.float64(model_time_seconds),
+            mode=np.asarray(result.mode),
+            sdir=(
+                result.sdir
+                if result.sdir is not None
+                else np.empty(0, dtype=np.float32)
+            ),
+            knet=(
+                result.knet
+                if result.knet is not None
+                else np.empty(0, dtype=np.float32)
+            ),
+            sveg=(
+                result.sveg
+                if result.sveg is not None
+                else np.empty(0, dtype=np.float32)
+            ),
+        )
+    temp_path.replace(path)
+
+
+def _load_step_checkpoint(
+    checkpoint_dir: Path,
+    idx: int,
+    model_time_seconds: float,
+    nfacets: int,
+) -> _FacetStepResult | None:
+    path = _checkpoint_path(checkpoint_dir, idx)
+    if not path.exists():
+        return None
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            stored_idx = int(data["index"])
+            stored_time = float(data["model_time_seconds"])
+            mode = str(data["mode"].item())
+            sdir_data = np.asarray(data["sdir"], dtype=np.float32)
+            knet_data = np.asarray(data["knet"], dtype=np.float32)
+            sveg_data = np.asarray(data["sveg"], dtype=np.float32)
+    except (OSError, ValueError, KeyError):
+        return None
+    if stored_idx != idx or stored_time != float(model_time_seconds):
+        return None
+    if sdir_data.size not in (0, nfacets) or knet_data.size not in (0, nfacets):
+        return None
+    return _FacetStepResult(
+        index=idx,
+        mode=mode,
+        sdir=sdir_data if sdir_data.size else None,
+        knet=knet_data if knet_data.size else None,
+        sveg=sveg_data if sveg_data.size else None,
+        timing={},
+        sample=TimingSample(0.0, 0.0, None),
+        worker_pid=os.getpid(),
+        resumed=True,
+    )
+
+
 def map_atmosphere_to_facets(
     prep: Any,
     atmosphere: ShortwaveAtmosphere,
@@ -842,8 +1067,17 @@ def map_atmosphere_to_facets(
     method: str | None = None,
     verbose: bool = True,
     timing: ShortwaveTimingRecorder | None = None,
+    workers: int = 1,
+    checkpoint_dir: Path | None = None,
+    resume: bool = False,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
     """Map atmospheric shortwave forcing to uDALES facets."""
+    workers = int(workers)
+    if workers < 1:
+        raise ValueError("workers must be >= 1")
+    if resume and checkpoint_dir is None:
+        raise ValueError("resume requires checkpoint_dir")
+
     setup_timer = Stopwatch() if timing is not None else None
     sim = prep.sim
     radiation = prep.radiation
@@ -862,6 +1096,24 @@ def map_atmosphere_to_facets(
 
     nt = atmosphere.times.size
     nfacets = albedo.size
+    context = _FacetMappingContext(
+        radiation=radiation,
+        atmosphere=atmosphere,
+        method=method_name,
+        resolution=resolution,
+        lscatter=lscatter,
+        albedo=albedo,
+        vf=vf,
+        svf=svf,
+        fss=fss,
+        nfacets=nfacets,
+    )
+    prepared_checkpoint_dir = None
+    if checkpoint_dir is not None:
+        prepared_checkpoint_dir = _prepare_checkpoint_dir(
+            checkpoint_dir, context, resume=resume
+        )
+
     sdir_all = np.zeros((nfacets, nt), dtype=np.float32)
     knet_all = np.zeros((nfacets, nt), dtype=np.float32)
     sveg_all: np.ndarray | None = None
@@ -883,108 +1135,127 @@ def map_atmosphere_to_facets(
             tzinfo=model_timezone,
         )
 
-    for idx, time_value in enumerate(atmosphere.times):
-        step_timer = Stopwatch() if timing is not None else None
-        step_timing: dict[str, float] = {}
+    def print_step(prefix: str, idx: int) -> None:
+        if not verbose:
+            return
+        time_value = atmosphere.times[idx]
         dni = float(atmosphere.dni[idx])
         dsky = float(atmosphere.dsky[idx])
         zenith = float(atmosphere.zenith[idx])
-        mode = "night"
-        if verbose:
-            print(
-                f"[{idx + 1:3d}/{nt}] t={time_value:8.1f}s "
-                f"GHI={atmosphere.ghi[idx]:8.3f} DNI={dni:8.3f} "
-                f"Dsky={dsky:8.3f} zenith={zenith:7.3f}",
-                flush=True,
+        print(
+            f"[{prefix} {idx + 1:3d}/{nt}] t={time_value:8.1f}s "
+            f"GHI={atmosphere.ghi[idx]:8.3f} DNI={dni:8.3f} "
+            f"Dsky={dsky:8.3f} zenith={zenith:7.3f}",
+            flush=True,
+        )
+
+    def consume_result(result: _FacetStepResult) -> None:
+        nonlocal sveg_all
+        idx = result.index
+        if result.sdir is not None:
+            sdir_all[:, idx] = result.sdir
+        if result.knet is not None:
+            knet_all[:, idx] = result.knet
+        if result.sveg is not None:
+            if sveg_all is None:
+                sveg_all = np.zeros((result.sveg.size, nt), dtype=np.float32)
+            sveg_all[:, idx] = result.sveg
+
+        if prepared_checkpoint_dir is not None and not result.resumed:
+            _write_step_checkpoint(
+                prepared_checkpoint_dir,
+                result,
+                float(atmosphere.times[idx]),
             )
 
-        if dni > 0.0 and zenith < 90.0:
-            nsun = nsun_from_angles(zenith, float(atmosphere.azimuth_local[idx]))
-            if abs(float(nsun[2])) >= MIN_DIRECT_COS_ZENITH:
-                mode = "direct"
-                timing_args = {"timing": step_timing} if timing is not None else {}
-                sdir, knet, sveg = radiation._compute_knet(
-                    nsun,
-                    dni,
-                    dsky,
-                    method_name,
-                    resolution,
-                    lscatter,
-                    albedo,
-                    vf,
-                    svf,
-                    fss,
-                    **timing_args,
-                )
-                sdir_all[:, idx] = np.asarray(sdir, dtype=np.float32)
-                knet_all[:, idx] = np.asarray(knet, dtype=np.float32)
-                if sveg is not None and np.asarray(sveg).size > 0:
-                    if sveg_all is None:
-                        sveg_all = np.zeros((np.asarray(sveg).size, nt), dtype=np.float32)
-                    sveg_all[:, idx] = np.asarray(sveg, dtype=np.float32)
-            elif dsky > 0.0:
-                mode = "diffuse"
-        elif dsky > 0.0:
-            mode = "diffuse"
-
-        if mode == "diffuse":
-            zero_sdir = np.zeros(nfacets, dtype=np.float64)
-            net_timer = Stopwatch() if timing is not None else None
-            if lscatter:
-                if vf is None or svf is None:
-                    raise ValueError("View factors are required for diffuse shortwave")
-                knet = radiation.calc_reflections_sw(zero_sdir, dsky, vf, svf, albedo)
-            else:
-                if fss is None:
-                    raise ValueError("Fss is required for non-scattering shortwave")
-                knet = _radiation_compute.net_shortwave_nonscattering(
-                    zero_sdir, dsky, fss, albedo
-                )
-            knet_all[:, idx] = np.asarray(knet, dtype=np.float32)
-            if net_timer is not None:
-                net_sample = net_timer.sample()
-                step_timing["net_wall_seconds"] = net_sample.wall_seconds
-                step_timing["net_cpu_seconds"] = net_sample.cpu_seconds
-
-        if timing is not None and step_timer is not None:
+        if timing is not None:
             if model_start is None:
                 raise RuntimeError("Internal error: benchmark model start is unavailable")
-            step_sample = step_timer.sample()
             timing.record_timestamp(
                 {
                     "index": idx + 1,
                     "total": nt,
-                    "model_time_seconds": float(time_value),
+                    "model_time_seconds": float(atmosphere.times[idx]),
                     "simulation_datetime": (
-                        model_start + timedelta(seconds=float(time_value))
+                        model_start
+                        + timedelta(seconds=float(atmosphere.times[idx]))
                     ).isoformat(),
-                    "mode": mode,
+                    "mode": result.mode,
                     "ghi_w_m2": float(atmosphere.ghi[idx]),
-                    "dni_w_m2": dni,
-                    "dsky_w_m2": dsky,
-                    "zenith_degrees": zenith,
+                    "dni_w_m2": float(atmosphere.dni[idx]),
+                    "dsky_w_m2": float(atmosphere.dsky[idx]),
+                    "zenith_degrees": float(atmosphere.zenith[idx]),
                     "azimuth_local_degrees": float(atmosphere.azimuth_local[idx]),
-                    "direct_wall_seconds": step_timing.get("direct_wall_seconds", 0.0),
-                    "direct_cpu_seconds": step_timing.get("direct_cpu_seconds", 0.0),
-                    "net_wall_seconds": step_timing.get("net_wall_seconds", 0.0),
-                    "net_cpu_seconds": step_timing.get("net_cpu_seconds", 0.0),
-                    "step_wall_seconds": step_sample.wall_seconds,
-                    "step_cpu_seconds": step_sample.cpu_seconds,
+                    "direct_wall_seconds": result.timing.get(
+                        "direct_wall_seconds", 0.0
+                    ),
+                    "direct_cpu_seconds": result.timing.get(
+                        "direct_cpu_seconds", 0.0
+                    ),
+                    "net_wall_seconds": result.timing.get("net_wall_seconds", 0.0),
+                    "net_cpu_seconds": result.timing.get("net_cpu_seconds", 0.0),
+                    "step_wall_seconds": result.sample.wall_seconds,
+                    "step_cpu_seconds": result.sample.cpu_seconds,
+                    "peak_rss_mib": result.sample.peak_rss_mib,
+                    "worker_pid": result.worker_pid,
+                    "resumed": result.resumed,
                 }
             )
-            if verbose:
-                peak_text = (
-                    f"{step_sample.peak_rss_mib:.1f} MiB"
-                    if step_sample.peak_rss_mib is not None
-                    else "n/a"
-                )
-                print(
-                    f"[timing {idx + 1:3d}/{nt}] mode={mode:<7s} "
-                    f"wall={step_sample.wall_seconds:.3f}s "
-                    f"cpu={step_sample.cpu_seconds:.3f}s "
-                    f"peak_rss={peak_text}",
-                    flush=True,
-                )
+
+        if verbose:
+            peak_text = (
+                f"{result.sample.peak_rss_mib:.1f} MiB"
+                if result.sample.peak_rss_mib is not None
+                else "n/a"
+            )
+            action = "resumed" if result.resumed else "done"
+            print(
+                f"[{action} {idx + 1:3d}/{nt}] mode={result.mode:<7s} "
+                f"wall={result.sample.wall_seconds:.3f}s "
+                f"cpu={result.sample.cpu_seconds:.3f}s "
+                f"peak_rss={peak_text} pid={result.worker_pid}",
+                flush=True,
+            )
+
+    pending: list[int] = []
+    for idx, time_value in enumerate(atmosphere.times):
+        result = None
+        if resume and prepared_checkpoint_dir is not None:
+            result = _load_step_checkpoint(
+                prepared_checkpoint_dir,
+                idx,
+                float(time_value),
+                nfacets,
+            )
+        if result is None:
+            pending.append(idx)
+        else:
+            consume_result(result)
+
+    if workers == 1:
+        for idx in pending:
+            print_step("start", idx)
+            consume_result(_compute_facet_step(context, idx))
+    elif pending:
+        if "fork" not in multiprocessing.get_all_start_methods():
+            raise RuntimeError("Parallel facet mapping requires multiprocessing fork support")
+        process_count = min(workers, len(pending))
+        if verbose:
+            print(
+                f"[parallel] workers={process_count} pending={len(pending)}",
+                flush=True,
+            )
+        global _FACET_MAPPING_CONTEXT
+        _FACET_MAPPING_CONTEXT = context
+        try:
+            mp_context = multiprocessing.get_context("fork")
+            with mp_context.Pool(processes=process_count) as pool:
+                for result in pool.imap_unordered(
+                    _facet_mapping_worker, pending, chunksize=1
+                ):
+                    consume_result(result)
+        finally:
+            _FACET_MAPPING_CONTEXT = None
 
     return sdir_all, knet_all, sveg_all
 
@@ -1004,6 +1275,9 @@ def generate_timedepsw_from_harmonie(
     method: str | None = None,
     verbose: bool = True,
     timing_prefix: Path | None = None,
+    workers: int = 1,
+    checkpoint_dir: Path | None = None,
+    resume: bool = False,
 ) -> TimedepShortwaveResult | ShortwaveAtmosphere:
     """Generate HARMONIE shortwave inputs with optional benchmark timing."""
     case_dir = Path(case_dir).expanduser().resolve()
@@ -1017,6 +1291,13 @@ def generate_timedepsw_from_harmonie(
                 "version": version,
                 "method_override": method,
                 "atmos_only": atmos_only,
+                "workers": int(workers),
+                "checkpoint_dir": (
+                    str(Path(checkpoint_dir).expanduser())
+                    if checkpoint_dir is not None
+                    else None
+                ),
+                "resume": resume,
             }
         )
         timing = ShortwaveTimingRecorder(
@@ -1041,6 +1322,9 @@ def generate_timedepsw_from_harmonie(
             method=method,
             verbose=verbose,
             timing=timing,
+            workers=workers,
+            checkpoint_dir=checkpoint_dir,
+            resume=resume,
         )
     except BaseException as exc:
         if timing is not None:
@@ -1081,6 +1365,9 @@ def _generate_timedepsw_from_harmonie(
     method: str | None = None,
     verbose: bool = True,
     timing: ShortwaveTimingRecorder | None = None,
+    workers: int = 1,
+    checkpoint_dir: Path | None = None,
+    resume: bool = False,
 ) -> TimedepShortwaveResult | ShortwaveAtmosphere:
     """Generate ``timedepsw.inp.<expnr>`` from HARMONIE ``ssrd``.
 
@@ -1177,6 +1464,9 @@ def _generate_timedepsw_from_harmonie(
             method=method,
             verbose=verbose,
             timing=timing,
+            workers=workers,
+            checkpoint_dir=checkpoint_dir,
+            resume=resume,
         )
 
     with timed_stage(timing, "write_timedepsw"):

--- a/tools/python/udprep/radiation_timing.py
+++ b/tools/python/udprep/radiation_timing.py
@@ -42,6 +42,8 @@ TIMESTAMP_FIELDS = (
     "step_cpu_seconds",
     "cumulative_wall_seconds",
     "peak_rss_mib",
+    "worker_pid",
+    "resumed",
     "completed_at_utc",
 )
 
@@ -58,12 +60,12 @@ class Stopwatch:
 
     def __init__(self) -> None:
         self._wall_start = time.perf_counter()
-        self._cpu_start = time.process_time()
+        self._cpu_start = process_tree_cpu_seconds()
 
     def sample(self) -> TimingSample:
         return TimingSample(
             wall_seconds=time.perf_counter() - self._wall_start,
-            cpu_seconds=time.process_time() - self._cpu_start,
+            cpu_seconds=process_tree_cpu_seconds() - self._cpu_start,
             peak_rss_mib=peak_rss_mib(),
         )
 
@@ -76,6 +78,15 @@ def peak_rss_mib() -> float | None:
     if sys.platform == "darwin":
         return value / (1024.0 * 1024.0)
     return value / 1024.0
+
+
+def process_tree_cpu_seconds() -> float:
+    """Return CPU time for this process and any completed children."""
+    if resource is None:
+        return time.process_time()
+    own = resource.getrusage(resource.RUSAGE_SELF)
+    children = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return own.ru_utime + own.ru_stime + children.ru_utime + children.ru_stime
 
 
 def _sha256(path: Path) -> str:
@@ -194,7 +205,8 @@ class ShortwaveTimingRecorder:
     def record_timestamp(self, values: dict[str, Any]) -> None:
         row = {field: values.get(field, "") for field in TIMESTAMP_FIELDS}
         row["cumulative_wall_seconds"] = self.elapsed_wall_seconds()
-        row["peak_rss_mib"] = peak_rss_mib()
+        if "peak_rss_mib" not in values:
+            row["peak_rss_mib"] = peak_rss_mib()
         row["completed_at_utc"] = datetime.now(timezone.utc).isoformat()
         self._writer.writerow(row)
         self._handle.flush()

--- a/tools/python/udprep/radiation_timing.py
+++ b/tools/python/udprep/radiation_timing.py
@@ -1,0 +1,249 @@
+"""Lightweight benchmark timing for radiation preprocessing."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import platform
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - unavailable on Windows
+    resource = None
+
+
+TIMESTAMP_FIELDS = (
+    "index",
+    "total",
+    "model_time_seconds",
+    "simulation_datetime",
+    "mode",
+    "ghi_w_m2",
+    "dni_w_m2",
+    "dsky_w_m2",
+    "zenith_degrees",
+    "azimuth_local_degrees",
+    "direct_wall_seconds",
+    "direct_cpu_seconds",
+    "net_wall_seconds",
+    "net_cpu_seconds",
+    "step_wall_seconds",
+    "step_cpu_seconds",
+    "cumulative_wall_seconds",
+    "peak_rss_mib",
+    "completed_at_utc",
+)
+
+
+@dataclass(frozen=True)
+class TimingSample:
+    wall_seconds: float
+    cpu_seconds: float
+    peak_rss_mib: float | None
+
+
+class Stopwatch:
+    """Measure elapsed monotonic wall time and process CPU time."""
+
+    def __init__(self) -> None:
+        self._wall_start = time.perf_counter()
+        self._cpu_start = time.process_time()
+
+    def sample(self) -> TimingSample:
+        return TimingSample(
+            wall_seconds=time.perf_counter() - self._wall_start,
+            cpu_seconds=time.process_time() - self._cpu_start,
+            peak_rss_mib=peak_rss_mib(),
+        )
+
+
+def peak_rss_mib() -> float | None:
+    """Return peak resident memory for this process in MiB."""
+    if resource is None:
+        return None
+    value = float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    if sys.platform == "darwin":
+        return value / (1024.0 * 1024.0)
+    return value / 1024.0
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git_metadata(repo_root: Path) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    try:
+        commit = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        status = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain=v1"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+    except (OSError, subprocess.CalledProcessError):
+        return metadata
+    metadata["git_commit"] = commit
+    metadata["git_dirty"] = bool(status)
+    metadata["git_status"] = status
+    return metadata
+
+
+def benchmark_metadata(repo_root: Path, case_dir: Path) -> dict[str, Any]:
+    """Capture enough runtime provenance to reproduce a benchmark."""
+    metadata: dict[str, Any] = {
+        "case_dir": str(case_dir),
+        "command": sys.argv,
+        "hostname": socket.gethostname(),
+        "pid": os.getpid(),
+        "platform": platform.platform(),
+        "python_executable": sys.executable,
+        "python_version": platform.python_version(),
+    }
+    if hasattr(os, "sched_getaffinity"):
+        metadata["cpu_affinity"] = sorted(os.sched_getaffinity(0))
+    metadata.update(_git_metadata(repo_root))
+
+    extensions = sorted(
+        (repo_root / "tools/python/udprep").glob("directshortwave_f2py*.so")
+    )
+    if extensions:
+        extension = extensions[0]
+        metadata["directshortwave_extension"] = str(extension)
+        metadata["directshortwave_extension_sha256"] = _sha256(extension)
+    return metadata
+
+
+class ShortwaveTimingRecorder:
+    """Write durable per-timestamp progress and an atomic JSON summary."""
+
+    def __init__(
+        self,
+        prefix: Path,
+        *,
+        metadata: dict[str, Any],
+        overwrite: bool,
+    ) -> None:
+        prefix = Path(prefix).expanduser().resolve()
+        self.csv_path = Path(f"{prefix}.timestamps.csv")
+        self.summary_path = Path(f"{prefix}.summary.json")
+        existing = [path for path in (self.csv_path, self.summary_path) if path.exists()]
+        if existing and not overwrite:
+            raise FileExistsError(
+                "Timing output already exists. Pass --overwrite to replace: "
+                + ", ".join(str(path) for path in existing)
+            )
+
+        self.csv_path.parent.mkdir(parents=True, exist_ok=True)
+        self.summary_path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.csv_path.open("w", encoding="ascii", newline="")
+        self._writer = csv.DictWriter(self._handle, fieldnames=TIMESTAMP_FIELDS)
+        self._writer.writeheader()
+        self._handle.flush()
+
+        self._run_timer = Stopwatch()
+        self._summary: dict[str, Any] = {
+            "schema_version": 1,
+            "status": "running",
+            "started_at_utc": datetime.now(timezone.utc).isoformat(),
+            "timestamps_completed": 0,
+            "stages": [],
+            "metadata": metadata,
+        }
+        self._write_summary()
+
+    def elapsed_wall_seconds(self) -> float:
+        return self._run_timer.sample().wall_seconds
+
+    def update_metadata(self, **values: Any) -> None:
+        self._summary["metadata"].update(values)
+        self._write_summary()
+
+    def record_stage(self, name: str, sample: TimingSample) -> None:
+        self._summary["stages"].append(
+            {
+                "name": name,
+                "wall_seconds": sample.wall_seconds,
+                "cpu_seconds": sample.cpu_seconds,
+                "peak_rss_mib": sample.peak_rss_mib,
+                "completed_at_utc": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        self._write_summary()
+
+    def record_timestamp(self, values: dict[str, Any]) -> None:
+        row = {field: values.get(field, "") for field in TIMESTAMP_FIELDS}
+        row["cumulative_wall_seconds"] = self.elapsed_wall_seconds()
+        row["peak_rss_mib"] = peak_rss_mib()
+        row["completed_at_utc"] = datetime.now(timezone.utc).isoformat()
+        self._writer.writerow(row)
+        self._handle.flush()
+        self._summary["timestamps_completed"] += 1
+        self._write_summary()
+
+    def finish(
+        self,
+        *,
+        status: str,
+        total: TimingSample,
+        outputs: dict[str, str | None] | None = None,
+        error: str | None = None,
+    ) -> None:
+        self._summary.update(
+            {
+                "status": status,
+                "completed_at_utc": datetime.now(timezone.utc).isoformat(),
+                "total_wall_seconds": total.wall_seconds,
+                "total_cpu_seconds": total.cpu_seconds,
+                "peak_rss_mib": total.peak_rss_mib,
+            }
+        )
+        if outputs is not None:
+            self._summary["outputs"] = outputs
+        if error is not None:
+            self._summary["error"] = error
+        self._write_summary()
+        self._handle.close()
+
+    def _write_summary(self) -> None:
+        temp_path = self.summary_path.with_name(
+            f".{self.summary_path.name}.{os.getpid()}.tmp"
+        )
+        with temp_path.open("w", encoding="ascii") as handle:
+            json.dump(self._summary, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        temp_path.replace(self.summary_path)
+
+
+@contextmanager
+def timed_stage(
+    recorder: ShortwaveTimingRecorder | None, name: str
+) -> Iterator[None]:
+    if recorder is None:
+        yield
+        return
+    timer = Stopwatch()
+    try:
+        yield
+    finally:
+        recorder.record_stage(name, timer.sample())

--- a/tools/python/udprep/udprep_radiation.py
+++ b/tools/python/udprep/udprep_radiation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import warnings
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
@@ -1055,17 +1056,28 @@ class RadiationSection(Section):
         vf,
         svf: np.ndarray | None,
         fss: np.ndarray | None,
+        *,
+        timing: Dict[str, float] | None = None,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray | None]:
+        if timing is not None:
+            direct_wall_start = time.perf_counter()
+            direct_cpu_start = time.process_time()
         sdir, s_veg, _ = self.calc_direct_sw(
             nsun,
             irradiance,
             method=method,
             resolution=resolution,
         )
+        if timing is not None:
+            timing["direct_wall_seconds"] = time.perf_counter() - direct_wall_start
+            timing["direct_cpu_seconds"] = time.process_time() - direct_cpu_start
         if method == "scanline_f2py":
             # MATLAB's Fortran route writes Sdir.txt with f8.2 and reads it
             # back before computing Knet, so use the same precision here.
             sdir = np.round(sdir, 2)
+        if timing is not None:
+            net_wall_start = time.perf_counter()
+            net_cpu_start = time.process_time()
         if lscatter:
             if vf is None or svf is None:
                 raise ValueError("View factors are required for shortwave reflections")
@@ -1074,6 +1086,9 @@ class RadiationSection(Section):
             if fss is None:
                 raise ValueError("Fss is required for non-scattering shortwave")
             knet = _radiation_compute.net_shortwave_nonscattering(sdir, dsky, fss, albedo)
+        if timing is not None:
+            timing["net_wall_seconds"] = time.perf_counter() - net_wall_start
+            timing["net_cpu_seconds"] = time.process_time() - net_cpu_start
         return sdir, knet, s_veg
 
     @staticmethod

--- a/tools/python/udprep/udprep_radiation.py
+++ b/tools/python/udprep/udprep_radiation.py
@@ -760,6 +760,7 @@ class RadiationSection(Section):
                     azimuth = float(azimuth_interp[n]) - self.xazimuth
                     nsun = nsun_from_angles(solarzenith, azimuth)
                     dsky = float(Dsky_interp[n])
+                    step_start = time.perf_counter()
                     sdir, knet, s_veg = self._compute_knet(
                         nsun,
                         irradiance,
@@ -771,6 +772,9 @@ class RadiationSection(Section):
                         vf,
                         svf,
                         fss,
+                    )
+                    self._print_timedep_shortwave_progress(
+                        n, nt, t_val, method, time.perf_counter() - step_start
                     )
                     sdir_all[:, n] = sdir
                     knet_all[:, n] = knet
@@ -787,6 +791,7 @@ class RadiationSection(Section):
                     and irradiance > 0.0
                     and abs(np.cos(np.radians(solarzenith))) >= _MIN_SUN_VERTICAL
                 ):
+                    step_start = time.perf_counter()
                     sdir, knet, s_veg = self._compute_knet(
                         nsun,
                         irradiance,
@@ -798,6 +803,9 @@ class RadiationSection(Section):
                         vf,
                         svf,
                         fss,
+                    )
+                    self._print_timedep_shortwave_progress(
+                        n, nt, t_val, method, time.perf_counter() - step_start
                     )
                     sdir_all[:, n] = sdir
                     knet_all[:, n] = knet
@@ -813,6 +821,21 @@ class RadiationSection(Section):
         if s_veg_all is not None:
             self.write_timedepsveg(tSP, s_veg_all)
         _write_sig(timedepsw_path, sw_sig)
+
+    @staticmethod
+    def _print_timedep_shortwave_progress(
+        index: int,
+        total: int,
+        model_time_seconds: float,
+        method: str,
+        wall_seconds: float,
+    ) -> None:
+        print(
+            f"[shortwave {index + 1:3d}/{total}] "
+            f"t={model_time_seconds:8.1f}s mode=direct "
+            f"method={method} wall={wall_seconds:.3f}s",
+            flush=True,
+        )
 
     def write_timedepsw(self, tSP: np.ndarray, knet: np.ndarray) -> None:
         """Write time-dependent net shortwave (timedepsw.inp.<expnr>)."""

--- a/tools/write_inputs.py
+++ b/tools/write_inputs.py
@@ -45,19 +45,21 @@ Environment
 
     The shell wrapper tools/write_inputs.sh -p is the recommended entry point
     because it derives PREPROC_NCPU from &INPS/nompthreads before sourcing the
-    default View3D runtime configuration. If this Python script is invoked
-    directly for a case that runs View3D, export PREPROC_NCPU explicitly first
-    (use the namoptions nompthreads value, or 8 if nompthreads is omitted).
+    default View3D runtime configuration. It also defaults NUMBA_NUM_THREADS to
+    PREPROC_NCPU for the CPU-parallel facsec and moller shortwave backends. If
+    this Python script is invoked directly, export PREPROC_NCPU and
+    NUMBA_NUM_THREADS explicitly first (use the namoptions nompthreads value,
+    or 8 if nompthreads is omitted).
 
 Examples
 --------
     Example commands from the repository root.
 
     # Process a specific case directory
-    PREPROC_NCPU=8 python tools/write_inputs.py examples/101
+    PREPROC_NCPU=8 NUMBA_NUM_THREADS=8 python tools/write_inputs.py examples/101
 
     # Force regeneration of all outputs
-    PREPROC_NCPU=8 python tools/write_inputs.py examples/101 --force
+    PREPROC_NCPU=8 NUMBA_NUM_THREADS=8 python tools/write_inputs.py examples/101 --force
 """
 
 from __future__ import annotations

--- a/tools/write_inputs.sh
+++ b/tools/write_inputs.sh
@@ -159,6 +159,7 @@ case "$nompthreads" in
 		;;
 esac
 export PREPROC_NCPU="${nompthreads:-$default_nompthreads}"
+export NUMBA_NUM_THREADS="${NUMBA_NUM_THREADS:-$PREPROC_NCPU}"
 export PREPROC_WALLTIME="${PREPROC_WALLTIME:-24:00:00}"
 export PREPROC_MEM="${PREPROC_MEM:-128gb}"
 
@@ -211,6 +212,7 @@ export MATLAB_USE_USERWORK=0
 export PYTHONUNBUFFERED=1
 export GFORTRAN_UNBUFFERED_PRECONNECTED=1
 export PREPROC_NCPU="$PREPROC_NCPU"
+export NUMBA_NUM_THREADS="$NUMBA_NUM_THREADS"
 export PREPROC_MEM="$PREPROC_MEM"
 export VIEW3D_CONFIG="$VIEW3D_CONFIG"
 source_view3d_config() {


### PR DESCRIPTION
## Summary

This pull request accelerates direct shortwave preprocessing across the scanline, facsec, and Moller backends, and adds enough runtime visibility to diagnose long HARMONIE-to-uDALES conversions.

It addresses the performance bottlenecks documented in #350.

## What changed

### Scanline rasterization

- Allocate and initialize the raster scratch buffers once per solar calculation instead of allocating and clearing a full-frame logical array for every facet.
- Restrict parity scans and scratch cleanup to columns touched by the current triangle.
- Replace the quadratic insertion sort used for painter ordering with a stable merge sort, preserving the original equal-depth facet ordering.
- Apply equivalent changes to both the Python f2py kernel and the standalone SEB Fortran implementation.
- Keep the raster count traversal cache-friendly and preserve scanline output compatibility.

These changes remove the dominant `O(nfacets * raster_width * raster_height)` clearing cost and the `O(nfacets^2)` sorting cost identified in #350.

A controlled case 302 benchmark used the Central Paris geometry, `ishortwave = 1`, `psc_res = 0.5`, `dtSP = 10800 s`, and 11 shortwave timestamps. The optimized runs used the same inputs as the instrumented baseline:

| Configuration | Facet-mapping wall time | Mapping speedup | End-to-end wall time | Total speedup |
| --- | ---: | ---: | ---: | ---: |
| Original scanline | 54,074.42 s (15.02 h) | 1x | 54,417.44 s (15.12 h) | 1x |
| Optimized, 1 worker | 10.65 s | 5,075x | 364.96 s (6.08 min) | 149x |
| Optimized, 8 workers | 5.79 s | 9,341x | 342.67 s (5.71 min) | 159x |

The mapping-stage result isolates the scanline and timestamp-processing improvements. Once that stage falls to seconds, geometry loading and HARMONIE atmosphere preparation dominate the remaining end-to-end runtime, which is why total-runtime scaling is smaller than the kernel-stage speedup.

### Facsec and Moller ray tracing

- Remove unused per-cell energy state and dormant hit-count/debug state.
- Scalarize ray setup and intersection calculations to avoid temporary NumPy allocations inside hot Numba loops.
- Parallelize ray casting with `numba.prange` while retaining race-free per-ray hit storage and deterministic post-kernel accumulation.
- Preserve vegetation absorption with thread-local accumulation.
- Build the Moller cell-to-facet lookup as compact CSR data instead of Python list-heavy structures.
- Avoid allocating jitter arrays when ray jitter is disabled.

On the 5.28 million-ray benchmark used during development:

| Backend | Original | Optimized, 1 thread | 1-thread speedup | Optimized, 8 threads | 8-thread speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| facsec | 1.46 s | 1.14 s | 1.28x | 0.27 s | 5.41x |
| Moller | 2.70 s | 1.65 s | 1.64x | 0.38 s | 7.11x |

Facet shortwave and energy-budget outputs matched exactly in the benchmark. Vegetation accumulation differed only at approximately `1e-12`, consistent with parallel floating-point summation order.

### HARMONIE workflow and CPU configuration

- Add checkpoint/resume support, per-timestamp timing, wall/CPU time, peak RSS, process IDs, and structured CSV/JSON benchmark summaries to the HARMONIE shortwave converter.
- Add `--workers` support for safe timestamp-level multiprocessing.
- Update the example notebook with foreground and headless `nohup` commands, checkpointing, timing output, and recommended worker/thread settings.
- Export `NUMBA_NUM_THREADS` from `write_inputs.sh`, defaulting to `PREPROC_NCPU` while respecting an explicit user override.
- Propagate the thread setting into generated PBS preprocessing scripts.

For scanline conversion, multiple timestamp workers can be used with one Numba thread each. For facsec and Moller, one timestamp worker with multiple Numba threads avoids nested oversubscription.

### Logging cleanup

- Keep concise indexed per-timestamp progress in normal preprocessing.
- Emit detailed atmospheric, CPU, memory, and PID diagnostics only when an explicit timing recorder is requested.
- Preserve structured timing records in quiet mode.
- Replace the anonymous Fortran `Time = ...` line with backend-labelled Python progress.

## User impact

Large urban shortwave preprocessing runs no longer spend days repeatedly clearing full raster frames or sorting facets quadratically. Numba backends can use the CPU cores assigned to preprocessing, long HARMONIE conversions can resume from checkpoints, and normal logs now show which timestamp and backend are active without benchmark-only noise.

## Validation

- Rebuilt View3D, IBM f2py, and direct-shortwave f2py preprocessing components.
- Full Python library test stream: 418 tests passed, 11 skipped.
- Direct-shortwave integration tests passed for scanline, facsec, Moller, and vegetation paths.
- UDPrep integration tests passed.
- Python and MATLAB reference comparisons passed.
- Scanline regression outputs remained numerically unchanged.
- Facsec and Moller benchmark outputs matched the original implementation, apart from the expected negligible parallel vegetation summation-order difference.

Addresses #350.